### PR TITLE
Add version checks and an upgrade command (Resolves #16)

### DIFF
--- a/packages/static_shock_cli/README_PUBLISH.md
+++ b/packages/static_shock_cli/README_PUBLISH.md
@@ -1,0 +1,7 @@
+# Publishing static_shock_cli
+Follow these steps to publish a new version of `static_shock_cli`:
+
+ 1. Increment the package version in `pubspec.yaml`.
+ 2. Update the `CHANGELOG.md` with all changes since the last release.
+ 3. Run `dart run build_runner build` to update the package version number in generated code.
+ 4. Run `melos publish` to validate and publish the package.

--- a/packages/static_shock_cli/build.yaml
+++ b/packages/static_shock_cli/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      build_version:
+        options:
+          output: lib/version.dart

--- a/packages/static_shock_cli/lib/version.dart
+++ b/packages/static_shock_cli/lib/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '0.0.1-dev.4';

--- a/packages/static_shock_cli/pubspec.lock
+++ b/packages/static_shock_cli/pubspec.lock
@@ -49,6 +49,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "5e1929ad37d48bd382b124266cb8e521de5548d406a45a5ae6656c13dab73e37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.10"
+  build_version:
+    dependency: "direct dev"
+    description:
+      name: build_version
+      sha256: "4e8eafbf722eac3bd60c8d38f108c04bd69b80100f8792b32be3407725c7fa6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: "598a2a682e2a7a90f08ba39c0aaa9374c5112340f0a2e275f61b59389543d166"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.6.1"
   charcode:
     dependency: transitive
     description:
@@ -81,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.0"
   collection:
     dependency: transitive
     description:
@@ -113,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   equatable:
     dependency: transitive
     description:
@@ -133,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -161,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   html_unescape:
     dependency: transitive
     description:
@@ -329,6 +425,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   pointycastle:
     dependency: transitive
     description:
@@ -345,6 +449,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.4"
   protobuf:
     dependency: transitive
     description:
@@ -361,6 +473,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  pub_updater:
+    dependency: "direct main"
+    description:
+      name: pub_updater
+      sha256: "05ae70703e06f7fdeb05f7f02dd680b8aad810e87c756a618f33e1794635115c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
   sass:
     dependency: transitive
     description:
@@ -504,6 +632,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   tuple:
     dependency: transitive
     description:

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -18,7 +18,10 @@ dependencies:
   mason_logger: ^0.2.5
   shelf: ^1.4.1
   shelf_static: ^1.1.2
+  pub_updater: ^0.3.0
 
 dev_dependencies:
+  build_runner: ^2.4.5
+  build_version: ^2.1.1
   lints: ^2.0.0
   test: ^1.21.0


### PR DESCRIPTION
Add version checks and an upgrade command (Resolves #16)

The create and serve commands automatically check for newer versions on Pub:
```
Checking for newer versions of static_shock_cli...
New version of static_shock_cli is available: 0.1.0-dev.49 -> 0.0.1-dev.4

Creating a new Static Shock project...
Current directory: /Users/matt/Projects/static_shock/packages/static_shock_cli
```

A standalone `version` command is also available:
```
% shock version
Your current version of static_shock_cli is: 0.1.0-dev.49
Checking for newer versions of static_shock_cli on Pub...
A new version is available: 0.1.0-dev.49 -> 0.0.1-dev.4
```

And an `upgrade` command is available, which checks for a new version, and then upgrades the local version if a new one is available.