### PR TITLE
Page data is inherited from _data.yaml files in the source set (Resolves #43)

### DIFF
--- a/packages/static_shock/lib/src/data.dart
+++ b/packages/static_shock/lib/src/data.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:static_shock/src/files.dart';
+import 'package:static_shock/src/source_files.dart';
+import 'package:yaml/yaml.dart';
+
+/// Inspects all [sourceFiles] for files called `_data.yaml`, accumulates the content of those
+/// files into a [DataIndex], and returns that [DataIndex].
+Future<DataIndex> indexSourceData(SourceFiles sourceFiles) async {
+  print("Indexing source set data");
+  final dataIndex = DataIndex();
+  for (final directory in sourceFiles.sourceDirectories()) {
+    print("Inspecting directory: ${directory.path}");
+    final dataFile = File("${directory.directory.path}${Platform.pathSeparator}_data.yaml");
+    if (!dataFile.existsSync()) {
+      continue;
+    }
+
+    print("Found a _data.yaml file at: ${dataFile.path}");
+    final data = loadYaml(dataFile.readAsStringSync());
+    print("Loaded data:\n$data");
+
+    dataIndex.mergeAtPath(DirectoryRelativePath(directory.subPath), Map<String, Object>.from(data));
+  }
+
+  return dataIndex;
+}
+
+/// A hierarchical index of data.
+class DataIndex {
+  DataIndex() : _data = _DataNode("/");
+
+  final _DataNode _data;
+
+  Map<String, Object> getForPath(RelativePath path) {
+    final data = Map<String, Object>.from(_data.data);
+
+    var node = _data;
+    final directories = path.directories;
+    while (directories.isNotEmpty && node.children[directories.first] != null) {
+      node = node.children[directories.first]!;
+      data.addEntries(node.data.entries);
+    }
+
+    return data;
+  }
+
+  void mergeAtPath(RelativePath path, Map<String, Object> data) {
+    // TODO: how do we handle root-level data?
+    _DataNode node = _data;
+    final directories = path.directories;
+    for (final directory in directories) {
+      var childNode = node.children[directory];
+      if (childNode == null) {
+        childNode = _DataNode(directory);
+        node.children[directory] = childNode;
+      }
+      node = childNode;
+    }
+
+    node.data.addEntries(data.entries);
+  }
+}
+
+class _DataNode {
+  _DataNode(
+    this.directory, [
+    Map<String, Object>? data,
+    Map<String, _DataNode>? children,
+  ])  : data = data ?? {},
+        children = children ?? {};
+
+  final String directory;
+  final Map<String, Object> data;
+  final Map<String, _DataNode> children;
+}

--- a/packages/static_shock/lib/src/files.dart
+++ b/packages/static_shock/lib/src/files.dart
@@ -81,10 +81,13 @@ class FilePrefixExcluder implements Excluder {
   int get hashCode => _prefix.hashCode;
 }
 
-class RelativePath {
+abstract class RelativePath {
   const RelativePath(this.value);
 
   final String value;
+
+  /// The list of directory names that comprise this path.
+  List<String> get directories;
 
   @override
   bool operator ==(Object other) =>
@@ -99,6 +102,9 @@ class RelativePath {
 
 class DirectoryRelativePath extends RelativePath {
   const DirectoryRelativePath(super.value);
+
+  @override
+  List<String> get directories => value.split(Platform.pathSeparator).where((item) => item.isNotEmpty).toList();
 }
 
 class FileRelativePath implements RelativePath {
@@ -141,6 +147,9 @@ class FileRelativePath implements RelativePath {
   final String directoryPath;
   final String filename;
   final String extension;
+
+  @override
+  List<String> get directories => directoryPath.split(Platform.pathSeparator).where((item) => item.isNotEmpty).toList();
 
   FileRelativePath copyWith({
     String? directoryPath,

--- a/packages/static_shock/lib/src/source_files.dart
+++ b/packages/static_shock/lib/src/source_files.dart
@@ -33,6 +33,8 @@ class SourceFiles {
 
   /// Returns all directories in the source directory, except excluded paths.
   Iterable<SourceDirectory> sourceDirectories([SourceFilter? filter]) {
+    final rootDirectory = SourceDirectory(directory, "/");
+
     return directory
         .listSync(recursive: true) //
         .whereType<Directory>()
@@ -41,7 +43,9 @@ class SourceFiles {
               subDirectory.path.substring(directory.path.length),
             ))
         .where((directory) => !_isExcluded(directory.subPath))
-        .where((file) => filter?.passesFilter(file) ?? true);
+        .where((file) => filter?.passesFilter(file) ?? true)
+        .toList()
+      ..insert(0, rootDirectory);
   }
 
   /// Returns all files in the source directory, except excluded paths.

--- a/packages/static_shock/pubspec.yaml
+++ b/packages/static_shock/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   mason_logger: ^0.2.5
   path: ^1.8.3
   sass: ^1.62.1
+  yaml: ^3.1.2
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -1,0 +1,13 @@
+docs_menu:
+  - title: Add a Page
+    id: add-a-page
+  - title: Copy CSS, JS, Images
+    id: copy-assets
+  - title: Compile Sass
+    id: compile-sass
+  - title: Display a Menu in a Page
+    id: display-a-menu-in-a-page
+  - title: Use Remote CSS and JS
+    id: use-remote-css-and-js
+  - title: Create RSS Feed
+    id: create-rss-feed

--- a/packages/static_shock_docs/source/guides/add-a-page.md
+++ b/packages/static_shock_docs/source/guides/add-a-page.md
@@ -1,19 +1,6 @@
 ---
 title: Add a Page
 layout: layouts/guides.jinja
-docs_menu:
-  - title: Add a Page
-    id: add-a-page
-  - title: Copy CSS, JS, Images
-    id: copy-assets
-  - title: Compile Sass
-    id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
-  - title: Use Remote CSS and JS
-    id: use-remote-css-and-js
-  - title: Create RSS Feed
-    id: create-rss-feed
 ---
 # Add a Page
 A page is a URL-addressable web page.

--- a/packages/static_shock_docs/source/guides/compile-sass.md
+++ b/packages/static_shock_docs/source/guides/compile-sass.md
@@ -1,19 +1,6 @@
 ---
 title: Compile Sass
 layout: layouts/guides.jinja
-docs_menu:
-  - title: Add a Page
-    id: add-a-page
-  - title: Copy CSS, JS, Images
-    id: copy-assets
-  - title: Compile Sass
-    id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
-  - title: Use Remote CSS and JS
-    id: use-remote-css-and-js
-  - title: Create RSS Feed
-    id: create-rss-feed
 ---
 # Compile Sass
 Sass (also known as SCSS) is a format for defining CSS in a more convenient and extensible way.

--- a/packages/static_shock_docs/source/guides/copy-assets.md
+++ b/packages/static_shock_docs/source/guides/copy-assets.md
@@ -1,19 +1,6 @@
 ---
 title: Copy Assets
 layout: layouts/guides.jinja
-docs_menu:
-  - title: Add a Page
-    id: add-a-page
-  - title: Copy CSS, JS, Images
-    id: copy-assets
-  - title: Compile Sass
-    id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
-  - title: Use Remote CSS and JS
-    id: use-remote-css-and-js
-  - title: Create RSS Feed
-    id: create-rss-feed
 ---
 # Copy Images, CSS, JS
 A static site typically contains many assets. An asset is a file served by a web server, which isn't a page.

--- a/packages/static_shock_docs/source/guides/create-rss-feed.md
+++ b/packages/static_shock_docs/source/guides/create-rss-feed.md
@@ -1,19 +1,6 @@
 ---
 title: Create RSS Feed
 layout: layouts/guides.jinja
-docs_menu:
-  - title: Add a Page
-    id: add-a-page
-  - title: Copy CSS, JS, Images
-    id: copy-assets
-  - title: Compile Sass
-    id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
-  - title: Use Remote CSS and JS
-    id: use-remote-css-and-js
-  - title: Create RSS Feed
-    id: create-rss-feed
 ---
 # Create RSS Feed
 

--- a/packages/static_shock_docs/source/guides/display-a-menu-in-a-page.md
+++ b/packages/static_shock_docs/source/guides/display-a-menu-in-a-page.md
@@ -1,19 +1,6 @@
 ---
 title: Display a Menu in a Page
 layout: layouts/guides.jinja
-docs_menu:
-  - title: Add a Page
-    id: add-a-page
-  - title: Copy CSS, JS, Images
-    id: copy-assets
-  - title: Compile Sass
-    id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
-  - title: Use Remote CSS and JS
-    id: use-remote-css-and-js
-  - title: Create RSS Feed
-    id: create-rss-feed
 ---
 # Display a Menu in a Page
 <div class="alert alert-danger" role="alert">

--- a/packages/static_shock_docs/source/guides/use-remote-css-and-js.md
+++ b/packages/static_shock_docs/source/guides/use-remote-css-and-js.md
@@ -1,19 +1,6 @@
 ---
 title: Use Remote CSS and JS
 layout: layouts/guides.jinja
-docs_menu:
-  - title: Add a Page
-    id: add-a-page
-  - title: Copy CSS, JS, Images
-    id: copy-assets
-  - title: Compile Sass
-    id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
-  - title: Use Remote CSS and JS
-    id: use-remote-css-and-js
-  - title: Create RSS Feed
-    id: create-rss-feed
 ---
 # Use Remote CSS and JS
 <div class="alert alert-danger" role="alert">

--- a/packages/static_shock_docs/source/index.jinja
+++ b/packages/static_shock_docs/source/index.jinja
@@ -58,6 +58,7 @@ title: Static Shock
       </section>
 
       <section id="content">
+
       {{
         components.codeSample({
           "title": "Copy static assets",


### PR DESCRIPTION
Page data is inherited from _data.yaml files in the source set (Resolves #43)

Replaced the repeated menu definition for the "Guides" pages with a single `_data.yaml` in the `/guides` directory.