### PR TITLE
Add 'shock build' command (Resolves #39)

### DIFF
--- a/packages/static_shock_cli/pubspec.lock
+++ b/packages/static_shock_cli/pubspec.lock
@@ -689,7 +689,7 @@ packages:
     source: hosted
     version: "1.2.0"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   shelf: ^1.4.1
   shelf_static: ^1.1.2
   pub_updater: ^0.3.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.5


### PR DESCRIPTION
Add 'shock build' command (Resolves #39)

The command attempts to match an executable file with the same name as the package. If it can't find that, it looks for `bin/main.dart`. 