### PR TITLE
shock serve now auto-refreshes HTML pages when any source file changes, also port is now configurable (Resolves #41)

### DIFF
--- a/packages/static_shock_cli/bin/static_shock_cli.dart
+++ b/packages/static_shock_cli/bin/static_shock_cli.dart
@@ -108,7 +108,7 @@ class ServeCommand extends Command with PubVersionCheck {
         help: "The port used to serve the Static Shock website via localhost.",
       )
       ..addFlag(
-        "findOpenPort",
+        "find-open-port",
         defaultsTo: true,
         help: "When flag is set, Static Stock looks for open ports if the desired port isn't available.",
       );
@@ -147,7 +147,7 @@ class ServeCommand extends Command with PubVersionCheck {
       _log.err("Tried to serve the website at an invalid port: '${argResults!["port"]}'");
       return;
     }
-    final isPortSearchingAllowed = argResults!["findOpenPort"] == true;
+    final isPortSearchingAllowed = argResults!["find-open-port"] == true;
 
     StaticShockDevServer(_log, buildWebsite).run(
       port: port,

--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -132,7 +132,7 @@ class StaticShockDevServer {
   FutureOr<Response> Function(Request) _createStaticSiteServerHandler() {
     return const Pipeline() //
         .addMiddleware(logRequests()) //
-        .addMiddleware(injectDevServerWebSocket(() => _port))
+        .addMiddleware(_injectDevServerWebSocket(() => _port))
         .addHandler(
           createStaticHandler(
             'build',
@@ -227,7 +227,7 @@ class StaticShockDevServer {
 /// a full page refresh so that the page is running the latest version from the server. This
 /// is kind of a like an automatic "hot restart" for every HTML page that this dev server
 /// serves.
-Middleware injectDevServerWebSocket(int Function() getPort, {void Function(String message, bool isError)? logger}) =>
+Middleware _injectDevServerWebSocket(int Function() getPort, {void Function(String message, bool isError)? logger}) =>
     (innerHandler) {
       return (request) async {
         final response = await innerHandler(request);

--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -46,6 +46,12 @@ class StaticShockDevServer {
   /// Whether another website build is desired after the one that's currently in-progress.
   bool isAnotherBuildQueued = false;
 
+  /// Starts a development mode web server.
+  ///
+  /// The dev server serves static assets, as expected. It also intercepts all HTML webpages
+  /// and injects JavaScript that causes a page refresh whenever the site is rebuilt.
+  ///
+  /// To stop the dev server, call [stop].
   Future<void> run({
     required int port,
     bool findAnOpenPort = false,
@@ -93,6 +99,7 @@ class StaticShockDevServer {
         .listen(_onSourceFileChange);
   }
 
+  /// Stops a dev server that was started with [run].
   Future<void> stop() async {
     if (!_isServing) {
       return;

--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:html/dom.dart';
+import 'package:html/parser.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart';
+import 'package:shelf_static/shelf_static.dart';
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:watcher/watcher.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'website_builder.dart';
+
+/// Web server for local Static Shock development.
+///
+/// This web server serves static assets, as expected, but also injects developer
+/// tools, such as injecting JavaScript to automatically refresh a page when its
+/// source changes on the server.
+class StaticShockDevServer {
+  StaticShockDevServer(
+    this._log,
+    this._buildWebsiteDelegate,
+  );
+
+  final Logger _log;
+
+  /// Delegate that (re)builds the website by running the Static Shock pipeline.
+  final WebsiteBuilder _buildWebsiteDelegate;
+
+  /// Whether this server is active.
+  bool _isServing = false;
+  HttpServer? _server;
+
+  /// The port that this dev server is listening to.
+  late int _port;
+
+  /// Websocket connections to every active webpage that's been served, used to
+  /// send refresh signals when the site rebuilds.
+  final _connectedWebpages = <WebSocketChannel>{};
+
+  /// Whether a website build is actively in-progress.
+  bool isBuilding = false;
+
+  /// Whether another website build is desired after the one that's currently in-progress.
+  bool isAnotherBuildQueued = false;
+
+  Future<void> run({
+    required int port,
+    bool findAnOpenPort = false,
+  }) async {
+    if (_isServing) {
+      _log.err("Tried to start a dev server, but it's already running!");
+      return;
+    }
+    _isServing = true;
+
+    _log.info("Serving a static site!");
+    int chosenPort = port;
+    const maxPortTryCount = 50;
+    final serverHandler = _createServerHandler();
+    do {
+      try {
+        _server = await serve(serverHandler, 'localhost', chosenPort);
+      } on SocketException {
+        if (!findAnOpenPort) {
+          rethrow;
+        }
+        if ((chosenPort - port) > maxPortTryCount) {
+          _log.err("Couldn't find open port on localhost. Tried ports from $port to $chosenPort.");
+          return;
+        }
+
+        chosenPort = chosenPort + 1;
+      }
+    } while (_server == null);
+
+    // Track the actual port that was chosen.
+    _port = chosenPort;
+
+    // Enable content compression
+    _server!.autoCompress = true;
+
+    _log.success('Serving at http://${_server!.address.host}:${_server!.port}');
+
+    // Rebuild the website whenever a source file changes.
+    DirectoryWatcher("${Directory.current.absolute.path}${Platform.pathSeparator}bin") //
+        .events
+        .listen(_onSourceFileChange);
+    DirectoryWatcher("${Directory.current.absolute.path}${Platform.pathSeparator}source") //
+        .events
+        .listen(_onSourceFileChange);
+  }
+
+  Future<void> stop() async {
+    if (!_isServing) {
+      return;
+    }
+
+    try {
+      await _server!.close();
+    } finally {
+      _server = null;
+      _connectedWebpages.clear();
+      _isServing = false;
+    }
+  }
+
+  FutureOr<Response> Function(Request) _createServerHandler() {
+    return (Request request) {
+      print("Server handler received request for: '${request.url.path}'");
+      if (request.url.path == 'ws') {
+        return _createDevServerSocketHandler()(request);
+      } else {
+        return _createStaticSiteServerHandler()(request);
+      }
+    };
+  }
+
+  /// Creates the static web server handler for the dev server.
+  ///
+  /// This handler serves HTML pages, CSS stylesheets, JS scripts, images, and other
+  /// static assets.
+  FutureOr<Response> Function(Request) _createStaticSiteServerHandler() {
+    return const Pipeline() //
+        .addMiddleware(logRequests()) //
+        .addMiddleware(injectDevServerWebSocket(() => _port))
+        .addHandler(
+          createStaticHandler(
+            'build',
+            defaultDocument: 'index.html',
+          ),
+        );
+  }
+
+  /// Creates a Shelf websocket handler, which we expect each webpage to connect to for
+  /// refresh signals.
+  ///
+  /// This dev server adds a snippet of JavaScript to every HTML page that it serves. That
+  /// JavaScript snippet connects a websocket to this handler. Whenever this server sends
+  /// a refresh message through the websocket, each connected webpage requests a refresh,
+  /// thereby receiving the latest version of itself from the server.
+  FutureOr<Response> Function(Request) _createDevServerSocketHandler() {
+    return webSocketHandler((WebSocketChannel webSocket) {
+      _log.detail("Adding new websocket: $webSocket - ID: ${webSocket.hashCode}");
+      _connectedWebpages.add(webSocket);
+
+      webSocket.stream.listen((message) {
+        _log.detail("Page websocket received message: '$message'");
+        webSocket.sink.add("echo $message");
+      });
+
+      webSocket.sink.done.then((webSocketImpl) {
+        // Note: The "web socket" we're given in this callback is of type WebSocketImpl, which is
+        // different from the WebSocketChannel type that we receive in the main callback above.
+        _log.detail("WebSocket is done! Removing it: $webSocket - ID: ${webSocket.hashCode}");
+        _connectedWebpages.remove(webSocket);
+      });
+    });
+  }
+
+  Future<void> _onSourceFileChange(WatchEvent event) async {
+    _log.detail("File system change (${event.type}): ${event.path}.");
+    if (isBuilding) {
+      // A website build is already on-going. We don't want to risk conflicting file outputs
+      // on the file system. Queue another build when the current build is done.
+      isAnotherBuildQueued = true;
+      return;
+    }
+
+    // Run a website build, and then keep rebuilding as long as more changes come in while
+    // we're running a build.
+    do {
+      _log.detail("Rebuilding the website.");
+      isBuilding = true;
+      isAnotherBuildQueued = false;
+
+      final stopwatch = Stopwatch()..start();
+      try {
+        final exitCode = await _buildWebsiteDelegate();
+        isBuilding = false;
+        stopwatch.stop();
+
+        if (exitCode == null) {
+          // A build pre-flight check failed, so the build never even started. Fizzle.
+          _log.err("Website build failed pre-flight checks. Build failed. Not refreshing pages.");
+          return;
+        }
+
+        if (exitCode != 0) {
+          // Something went wrong during the build. Don't refresh the pages because the
+          // pages probably won't exist. Fizzle.
+          _log.err("Website build encountered an error during the build ($exitCode). Not refreshing pages.");
+          return;
+        }
+      } catch (exception) {
+        // Something went wrong during the build. Don't refresh the pages because the
+        // pages probably won't exist. Fizzle.
+        _log.err("Website build encountered an error during the build ($exception). Not refreshing pages.");
+        stopwatch.stop();
+        isBuilding = false;
+        return;
+      }
+
+      _log.detail("Rebuilt website in ${stopwatch.elapsed.inMilliseconds}ms");
+
+      _log.detail("Notifying ${_connectedWebpages.length} connected webpages to refresh.");
+      for (final page in _connectedWebpages) {
+        page.sink.add("refresh");
+      }
+    } while (isAnotherBuildQueued);
+  }
+}
+
+/// Middleware, which adds a JavaScript snippet to every HTML page in which the JavaScript
+/// establishes a websocket with this server to receive a refresh signal from the server.
+///
+/// When this JavaScript snippet receives a refresh signal from the dev server, it requests
+/// a full page refresh so that the page is running the latest version from the server. This
+/// is kind of a like an automatic "hot restart" for every HTML page that this dev server
+/// serves.
+Middleware injectDevServerWebSocket(int Function() getPort, {void Function(String message, bool isError)? logger}) =>
+    (innerHandler) {
+      return (request) async {
+        final response = await innerHandler(request);
+
+        if (response.mimeType != "text/html") {
+          return response;
+        }
+
+        // This is an HTML page. Inject dev server websocket to enable auto-refresh.
+        final html = await response.readAsString();
+        final dom = parse(html);
+        dom.body!.append(DocumentFragment.html('''
+        <script>
+          // Create a WebSocket connection
+          var socket = new WebSocket('ws://localhost:${getPort()}/ws');
+          
+          socket.onopen = function() {
+            console.log('Opening auto-refresh signal websocket with dev server.');
+            // Tell the dev server our HTML page page so the dev server can
+            // invalidate us when that page changes.
+            console.log('Our page path of interest is: ', location.pathname);
+            socket.send(location.pathname);
+          };
+          
+          socket.onmessage = function(event) {
+            if (event.data == "refresh") {
+              console.log('The dev server sent us a refresh signal. Refreshing the page.');
+              location.reload();
+            }
+          };
+          
+          socket.onclose = function() {
+            console.log('The dev server auto-refresh websocket has been closed.');
+          };
+        </script>
+        '''));
+
+        // Update the HTML that we're serving to include the refresh JavaScript snippet.
+        return response.change(
+          body: dom.outerHtml,
+        );
+      };
+    };

--- a/packages/static_shock_cli/lib/src/website_builder.dart
+++ b/packages/static_shock_cli/lib/src/website_builder.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:mason/mason.dart';
+import 'package:yaml/yaml.dart';
+
+/// Builds a static shock website from a source directory.
+///
+/// Expects to find a `pubspec.yaml` in the current directory.
+///
+/// Expects to find a project name in the `pubspec.yaml`, which is then expected to lead
+/// to the executable file via `bin/[package_name].dart`.
+Future<int?> buildWebsite({
+  Logger? log,
+  bool attachBuildProcessToStdIo = true,
+}) async {
+  final pubspecFile = File("pubspec.yaml");
+  if (!pubspecFile.existsSync()) {
+    log?.err("Couldn't find pubspec.yaml. This must not be a Static Shock project.");
+    return null;
+  }
+
+  final pubspec = loadYaml(pubspecFile.readAsStringSync());
+  final packageName = pubspec["name"] as String?;
+  if (packageName == null || packageName.isEmpty) {
+    log?.err("Couldn't find the project's package name in pubspec.yaml.");
+    return null;
+  }
+
+  final packageNameExecutable = File("bin${Platform.pathSeparator}$packageName.dart");
+  final mainExecutable = File("bin${Platform.pathSeparator}main.dart");
+  if (!packageNameExecutable.existsSync() && !mainExecutable.existsSync()) {
+    log?.err("Couldn't find the project's executable. Please check your /bin directory.");
+    return null;
+  }
+
+  final executableFile = packageNameExecutable.existsSync() ? packageNameExecutable : mainExecutable;
+
+  log?.detail("Running Static Shock executable: ${executableFile.path}");
+  final process = await Process.start(
+    'dart',
+    [executableFile.path],
+  );
+
+  stdout.addStream(process.stdout);
+  stderr.addStream(process.stderr);
+
+  return process.exitCode;
+}
+
+typedef WebsiteBuilder = Future<int?> Function({bool attachBuildProcessToStdIo});

--- a/packages/static_shock_cli/lib/static_shock_cli.dart
+++ b/packages/static_shock_cli/lib/static_shock_cli.dart
@@ -1,3 +1,5 @@
 library static_shock_cli;
 
+export 'src/website_builder.dart';
+export 'src/dev_server.dart';
 export 'src/version.dart';

--- a/packages/static_shock_cli/pubspec.lock
+++ b/packages/static_shock_cli/pubspec.lock
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -257,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  html:
+    dependency: "direct main"
+    description:
+      name: html
+      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.4"
   html_unescape:
     dependency: transitive
     description:
@@ -522,7 +538,7 @@ packages:
     source: hosted
     version: "1.1.2"
   shelf_web_socket:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shelf_web_socket
       sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
@@ -673,7 +689,7 @@ packages:
     source: hosted
     version: "1.1.0"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -21,6 +21,9 @@ dependencies:
   pub_updater: ^0.3.0
   yaml: ^3.1.2
   watcher: ^1.1.0
+  html: ^0.15.4
+  shelf_web_socket: ^1.0.4
+  web_socket_channel: ^2.4.0
 
 dev_dependencies:
   build_runner: ^2.4.5


### PR DESCRIPTION
shock serve now auto-refreshes HTML pages when any source file changes, also port is now configurable (Resolves #41)

During `shock serve`, the `/source` directory is watched. Any reported file system change triggers a full website rebuild.

The `shock serve` dev server now intercepts all HTML files that it serves and injects some JavaScript that connects a websocket with the dev server. Every time `shock serve` rebuilds the website, it notifies all registered websockets that a change has occurred, and the injected JavaScript refreshes the whole page.

Users can now specify the server port with the `--port` flag. Additionally, if the desired port is in use, the server will try to find a nearby open port. Port searching can be disabled with the `--no-find-open-port` flag.

In the future, it might be a good idea to have the server send the updated HTML for the page, rather than doing a full refresh, so that some page state might be preserved across the reload.

In the future, it might be good to only refresh a page when that particular page and its dependencies change. But, it's unclear how to calculate the dependencies. An HTML page might have any number of dependencies on CSS files, JS files, images, etc. Also, some of these dependencies might not exist until runtime, due to JavaScript creating the dependencies.

In the future, it would be good to improve the website build time. It's currently sitting at a few seconds to build a very simple website. This is too long for effective auto-refresh on larger and more complicated websites.