### PR TITLE
Allow arbitrary template functions, which makes it possible to convert markdown front matter properties to HTML within a template (Resolves #64)

### DIFF
--- a/packages/static_shock/lib/src/pipeline.dart
+++ b/packages/static_shock/lib/src/pipeline.dart
@@ -44,6 +44,28 @@ abstract class StaticShockPipeline {
   /// by [PageLoader]s, before the [Page] is rendered by a [PageRenderer].
   void transformPages(PageTransformer transformer);
 
+  /// Adds the given [templateFunction] to the pipeline, making the function available
+  /// during page template rendering via the given [name].
+  ///
+  /// Example - Register a function that converts Markdown to inline HTML:
+  ///
+  ///     pipeline.addTemplateFunction("md", (markdown) => markdownToHtml(markdown, inlineOnly: true));
+  ///
+  /// The registered function can then be used within a page template:
+  ///
+  ///     ---
+  ///     some_property: This is **markdown** in a *Front Matter* property.
+  ///     ---
+  ///     <html>
+  ///       <body>
+  ///         <h1>Markdown from Front Matter</h2>
+  ///         <!-- The following lines takes the value of some_property and passes it into the md() function -->
+  ///         <p>{{ md(some_property) }}</p>
+  ///       <body>
+  ///     </html>
+  ///
+  void addTemplateFunction(String name, Function templateFunction);
+
   /// Adds the given [PageRenderer] to the pipeline, which takes a [Page] and serializes
   /// that [Page] to an HTML page in the build set.
   void renderPages(PageRenderer renderer);
@@ -90,6 +112,32 @@ class StaticShockPipelineContext {
   void putLayout(Layout layout) {
     _layouts[layout.path] = layout;
   }
+
+  /// Functions that should be available during template rendering.
+  Map<String, Function> get templateFunctions => Map<String, Function>.from(_templateFunctions);
+  final _templateFunctions = <String, Function>{};
+
+  /// Adds the given [templateFunction] to the pipeline, making the function available
+  /// during page template rendering via the given [name].
+  ///
+  /// Example - Register a function that converts Markdown to inline HTML:
+  ///
+  ///     pipeline.addTemplateFunction("md", (markdown) => markdownToHtml(markdown, inlineOnly: true));
+  ///
+  /// The registered function can then be used within a page template:
+  ///
+  ///     ---
+  ///     some_property: This is **markdown** in a *Front Matter* property.
+  ///     ---
+  ///     <html>
+  ///       <body>
+  ///         <h1>Markdown from Front Matter</h2>
+  ///         <!-- The following lines takes the value of some_property and passes it into the md() function -->
+  ///         <p>{{ md(some_property) }}</p>
+  ///       <body>
+  ///     </html>
+  ///
+  void putTemplateFunction(String name, Function templateFunction) => _templateFunctions[name] = templateFunction;
 
   /// All components loaded into the pipeline.
   Map<String, Component> get components => Map<String, Component>.from(_components);

--- a/packages/static_shock/lib/src/plugins/jinja.dart
+++ b/packages/static_shock/lib/src/plugins/jinja.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:jinja/jinja.dart';
+import 'package:markdown/markdown.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/pages.dart';
@@ -127,6 +128,7 @@ class JinjaPageRenderer implements PageRenderer {
     final pageData = {
       ...page.data,
       "content": page.destinationContent ?? page.sourceContent,
+      ...context.templateFunctions,
       ...context.pagesIndex.buildPageIndexDataForTemplates(),
       "components": {
         // Maps component name to a factory method: "footer": () -> "<div>...</div>"

--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -14,9 +14,12 @@ class MarkdownPlugin implements StaticShockPlugin {
 
   @override
   FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
-    pipeline.pick(const ExtensionPicker("md"));
-    pipeline.loadPages(MarkdownPageLoader(context.log));
-    pipeline.renderPages(MarkdownPageRenderer(context.log));
+    pipeline
+      ..pick(const ExtensionPicker("md"))
+      ..loadPages(MarkdownPageLoader(context.log))
+      ..renderPages(MarkdownPageRenderer(context.log));
+
+    context.putTemplateFunction("md", (String markdown) => markdownToHtml(markdown, inlineOnly: true));
   }
 }
 

--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -102,6 +102,30 @@ class StaticShock implements StaticShockPipeline {
   void transformPages(PageTransformer transformer) => _pageTransformers.add(transformer);
   late final Set<PageTransformer> _pageTransformers;
 
+  /// Adds the given [templateFunction] to the pipeline, making the function available
+  /// during page template rendering via the given [name].
+  ///
+  /// Example - Register a function that converts Markdown to inline HTML:
+  ///
+  ///     pipeline.addTemplateFunction("md", (markdown) => markdownToHtml(markdown, inlineOnly: true));
+  ///
+  /// The registered function can then be used within a page template:
+  ///
+  ///     ---
+  ///     some_property: This is **markdown** in a *Front Matter* property.
+  ///     ---
+  ///     <html>
+  ///       <body>
+  ///         <h1>Markdown from Front Matter</h2>
+  ///         <!-- The following lines takes the value of some_property and passes it into the md() function -->
+  ///         <p>{{ md(some_property) }}</p>
+  ///       <body>
+  ///     </html>
+  ///
+  @override
+  void addTemplateFunction(String name, Function templateFunction) =>
+      _context.putTemplateFunction(name, templateFunction);
+
   /// Adds the given [PageRenderer] to the pipeline, which takes a [Page] and serializes
   /// that [Page] to an HTML page in the build set.
   @override


### PR DESCRIPTION
Allow arbitrary template functions, which makes it possible to convert markdown front matter properties to HTML within a template (Resolves #64)

Front Matter properties can be encoded as Markdown and used as HTML by translating those properties within a page template:

```jinja
<!--
my_property: This is **Markdown** with `code`.
-->
<html>
  <body>
    <p>{{ md(my_property) }}</p>
  </body>
</html>
```