### PR TITLE
Make pages sortable (Resolves #66)

### DIFF
--- a/packages/static_shock/lib/src/pages.dart
+++ b/packages/static_shock/lib/src/pages.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:mason_logger/mason_logger.dart';
+
 import 'files.dart';
 import 'pipeline.dart';
 
@@ -87,8 +89,7 @@ class PagesIndex {
       return sortOrder;
     }
 
-    // TODO: switch to logger
-    print("WARNING: Received unknown name for sort order: '$order'");
+    _log.warn("WARNING: Received unknown name for sort order: '$order'");
     return _SortOrder.ascending;
   }
 
@@ -244,3 +245,5 @@ $destinationContent
   @override
   String toString() => "[Page] - source: $sourcePath, destination: $destinationPath";
 }
+
+final _log = Logger(level: Level.verbose);

--- a/packages/static_shock/lib/src/plugins/jinja.dart
+++ b/packages/static_shock/lib/src/plugins/jinja.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:jinja/jinja.dart';
-import 'package:markdown/markdown.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/pages.dart';

--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -168,7 +168,42 @@ class StaticShockDevServer {
   }
 
   Future<void> _onSourceFileChange(WatchEvent event) async {
-    _log.detail("File system change (${event.type}): ${event.path}.");
+    try {
+      _log.detail("File system change (${event.type}): ${event.path}.");
+    } catch (exception) {
+      print("WARNING: Mason Logger threw exception during _onSourceFileChange()");
+      print(" - change type: ${event.type}");
+      print(" - change path: ${event.path}");
+      // This try/catch was added because during some file changes the dev server
+      // would blow up with the following stacktrace:
+      //
+      // Unhandled exception:
+      // Bad state: StreamSink is bound to a stream
+      // #0      _StreamSinkImpl._controller (dart:io/io_sink.dart:234:7)
+      // #1      _StreamSinkImpl.add (dart:io/io_sink.dart:154:5)
+      // #2      _IOSinkImpl.write (dart:io/io_sink.dart:287:5)
+      // #3      _StdSink._write (dart:io/stdio.dart:401:13)
+      // #4      _StdSink.writeln (dart:io/stdio.dart:419:5)
+      // #5      Logger.detail (package:mason_logger/src/mason_logger.dart:152:13)
+      // #6      StaticShockDevServer._onSourceFileChange (package:static_shock_cli/src/dev_server.dart:171:10)
+      // #7      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
+      // #8      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:365:11)
+      // #9      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:297:7)
+      // #10     _SyncBroadcastStreamController._sendData (dart:async/broadcast_stream_controller.dart:377:25)
+      // #11     _BroadcastStreamController.add (dart:async/broadcast_stream_controller.dart:244:5)
+      // #12     _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
+      // #13     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:365:11)
+      // #14     _DelayedData.perform (dart:async/stream_impl.dart:541:14)
+      // #15     _PendingEvents.handleNext (dart:async/stream_impl.dart:646:11)
+      // #16     _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:617:7)
+      // #17     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
+      // #18     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
+      // #19     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:118:13)
+      // #20     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:405:11)
+      // #21     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429:5)
+      // #22     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184:12)
+    }
+
     if (isBuilding) {
       // A website build is already on-going. We don't want to risk conflicting file outputs
       // on the file system. Queue another build when the current build is done.

--- a/packages/static_shock_docs/source/_includes/components/navbar.jinja
+++ b/packages/static_shock_docs/source/_includes/components/navbar.jinja
@@ -19,6 +19,10 @@
         </li>
 
         <li class="nav-item">
+          <a class="nav-link {% if title == "directory" %}active{% endif %}" href="/directory">Directory</a>
+        </li>
+
+        <li class="nav-item">
           <a class="nav-link" href="https://pub.dev/documentation/static_shock/latest/" target="_blank">API Docs</a>
         </li>
 

--- a/packages/static_shock_docs/source/directory.jinja
+++ b/packages/static_shock_docs/source/directory.jinja
@@ -1,0 +1,70 @@
+<!--
+title: Directory
+-->
+<!doctype html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }} | Static Shock</title>
+
+    {{ components.favicon() }}
+
+    {{ components.bootstrapJs() }}
+
+    {{ components.highlightJs() }}
+
+    {{ components.fontAwesome() }}
+
+    <link rel="stylesheet" href="/styles/theme.css">
+    <link rel="stylesheet" href="/styles/base_layout.css">
+    <link rel="stylesheet" href="/styles/inner_page.css">
+  </head>
+
+  <body class="inner-page">
+    <main>
+      {{ components.navbar({"title": title}) }}
+
+      {{
+        components.innerPageHeader({
+          "title": "Directory",
+          "subtitle": "All website pages in one directory"
+        })
+      }}
+
+      <section id="content">
+        <h2>Drafting</h2>
+        <ol>
+          {% for page in pages.byTag("drafting", sortBy="title", order="desc") %}
+          <li><a href="{{ page.data['url'] }}">{{ page.data['title'] }}</a></li>
+          {% endfor %}
+        </ol>
+
+        <h2>Styling</h2>
+        <ol>
+          {% for page in pages.byTag("styling", order="desc") %}
+          <li><a href="{{ page.data['url'] }}">{{ page.data['title'] }}</a></li>
+          {% endfor %}
+        </ol>
+
+        <h2>Publishing</h2>
+        <ol>
+          {% for page in pages.byTag("publishing", order="desc") %}
+          <li><a href="{{ page.data['url'] }}">{{ page.data['title'] }}</a></li>
+          {% endfor %}
+        </ol>
+
+        <h2>Extensions</h2>
+        <ol>
+          {% for page in pages.byTag("extensions", order="desc") %}
+          <li><a href="{{ page.data['url'] }}">{{ page.data['title'] }}</a></li>
+          {% endfor %}
+        </ol>
+      </section>
+    </main>
+
+    <footer>
+      {{ components.footer() }}
+    </footer>
+  </body>
+</html>

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -2,12 +2,14 @@ layout: layouts/guides.jinja
 docs_menu:
   - title: Add a Page
     id: add-a-page
+  - title: Directory of Pages
+    id: directory-of-pages
+  - title: Display a Menu in a Page
+    id: display-a-menu-in-a-page
   - title: Copy CSS, JS, Images
     id: copy-assets
   - title: Compile Sass
     id: compile-sass
-  - title: Display a Menu in a Page
-    id: display-a-menu-in-a-page
   - title: Use Remote CSS and JS
     id: use-remote-css-and-js
   - title: Create a Plugin

--- a/packages/static_shock_docs/source/guides/add-a-page.md
+++ b/packages/static_shock_docs/source/guides/add-a-page.md
@@ -1,5 +1,6 @@
 ---
 title: Add a Page
+tags: drafting
 ---
 # Add a Page
 A page is a URL-addressable web page.

--- a/packages/static_shock_docs/source/guides/compile-sass.md
+++ b/packages/static_shock_docs/source/guides/compile-sass.md
@@ -1,5 +1,6 @@
 ---
 title: Compile Sass
+tags: styling
 ---
 # Compile Sass
 Sass (also known as SCSS) is a format for defining CSS in a more convenient and extensible way.

--- a/packages/static_shock_docs/source/guides/copy-assets.md
+++ b/packages/static_shock_docs/source/guides/copy-assets.md
@@ -1,5 +1,6 @@
 ---
 title: Copy Assets
+tags: drafting
 ---
 # Copy Images, CSS, JS
 A static site typically contains many assets. An asset is a file served by a web server, which isn't a page.

--- a/packages/static_shock_docs/source/guides/create-a-plugin.md
+++ b/packages/static_shock_docs/source/guides/create-a-plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Create a Plugin
+tags: extensions
 ---
 # Create a Plugin
 

--- a/packages/static_shock_docs/source/guides/create-rss-feed.md
+++ b/packages/static_shock_docs/source/guides/create-rss-feed.md
@@ -1,5 +1,6 @@
 ---
 title: Create RSS Feed
+tags: publishing
 ---
 # Create RSS Feed
 

--- a/packages/static_shock_docs/source/guides/deploy-to-github-pages.md
+++ b/packages/static_shock_docs/source/guides/deploy-to-github-pages.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy to GitHub Pages
+tags: publishing
 ---
 # GitHub Pages
 GitHub provides a free tool for building, deploying, and serving static websites - it's called

--- a/packages/static_shock_docs/source/guides/directory-of-pages.md
+++ b/packages/static_shock_docs/source/guides/directory-of-pages.md
@@ -1,5 +1,6 @@
 ---
 title: Directory of Pages
+tags: drafting
 ---
 # Directory of Pages
 Use the pages index to display a list of page links for pages in your website.

--- a/packages/static_shock_docs/source/guides/directory-of-pages.md
+++ b/packages/static_shock_docs/source/guides/directory-of-pages.md
@@ -1,0 +1,65 @@
+---
+title: Directory of Pages
+---
+# Directory of Pages
+Use the pages index to display a list of page links for pages in your website.
+
+## List all pages
+List all pages in your website by iterating over all pages in the page index.
+
+```html
+<html lang="en">
+  <body>
+    {% for page in pages.all() %}
+      <a href="{{ page.data['url'] }}">{{ page.data['title'] }}</a>
+    {% endfor %}
+  </body>
+</html>
+```
+
+## List pages by tag name
+Once a website accumulates more than a few pages, you'll want to list pages by some sort of category.
+Pages are categorized by assigning "tags" to them.
+
+To associate a page with a tag, define desired tags in front matter.
+
+You can define tags in the front matter for Markdown pages.
+
+```markdown
+---
+title: My Page
+tags:
+ - flutter
+ - dart
+---
+# My Page
+```
+
+You can also defin tags in the front matter for Jinja pages.
+
+```html
+<!--
+ title: My Page
+ tags:
+  - flutter
+  - dart
+-->
+<html lang="en">
+  <head>
+    <title>My Page</title>
+  </head>
+  <body></body>
+</html>
+```
+
+After associating pages with tags, list pages per tag by using the tag iterator in the page index.
+
+```html
+<html lang="en">
+  <body>
+    {% for page in pages.byTag("flutter") %}
+      <a href="{{ page.data['url'] }}">{{ page.data['title'] }}</a>
+    {% endfor %}
+  </body>
+</html>
+```

--- a/packages/static_shock_docs/source/guides/display-a-menu-in-a-page.md
+++ b/packages/static_shock_docs/source/guides/display-a-menu-in-a-page.md
@@ -1,5 +1,6 @@
 ---
 title: Display a Menu in a Page
+tags: drafting
 ---
 # Display a Menu in a Page
 A page might display a menu of links, and it might appear as if the content changes within that


### PR DESCRIPTION
Jinja templates can query all pages, as well as all pages with a given tag. This PR adds the ability to sort all returned pages by a given page property, as well as ascending or descending result order.

Before this PR we seemed to be missing a way to query all pages. This PR adds all page access to Jinja templates.

This PR adds a top-level page to the Docs website called "Directory" which uses the tag queries with ascending and descending order.

This PR adds a Docs guide showing how to display a directory of pages based on a page query.