### PR TITLE
Added draft-mode plugin to remove page drafts, also added filters and tests to assemble menus based on page existence (Resolves #71)

### DIFF
--- a/packages/static_shock/lib/src/pages.dart
+++ b/packages/static_shock/lib/src/pages.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 import 'files.dart';

--- a/packages/static_shock/lib/src/pages.dart
+++ b/packages/static_shock/lib/src/pages.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 import 'files.dart';
@@ -13,6 +14,10 @@ abstract class PageLoader {
 
 abstract class PageTransformer {
   FutureOr<void> transformPage(StaticShockPipelineContext context, Page page);
+}
+
+abstract class PageFilter {
+  bool shouldInclude(StaticShockPipelineContext context, Page page);
 }
 
 abstract class PageRenderer {
@@ -33,6 +38,10 @@ class PagesIndex {
 
   void addPage(Page page) {
     _pages.add(page);
+  }
+
+  void removePage(Page page) {
+    _pages.remove(page);
   }
 
   /// Returns a data structure which represents a "page index" within a Jinja template.

--- a/packages/static_shock/lib/src/pipeline.dart
+++ b/packages/static_shock/lib/src/pipeline.dart
@@ -44,6 +44,17 @@ abstract class StaticShockPipeline {
   /// by [PageLoader]s, before the [Page] is rendered by a [PageRenderer].
   void transformPages(PageTransformer transformer);
 
+  /// Adds the given [PageFilter] to the pipeline, which can remove [Page]s before
+  /// those [Page]s are rendered.
+  ///
+  /// For example, a plugin might implement a "draft mode" in which article drafts
+  /// are excluded from the final build. While the draft mode could try to exclude
+  /// pages at the file level, that would require the draft mode plugin to understand
+  /// all possible file types so that it could parse the draft data. By filtering
+  /// after the creation of [Page]s, the draft mode plugin only needs to know which
+  /// property to check on the [Page] object.
+  void filterPages(PageFilter filter);
+
   /// Adds the given [templateFunction] to the pipeline, making the function available
   /// during page template rendering via the given [name].
   ///

--- a/packages/static_shock/lib/src/plugins/drafting.dart
+++ b/packages/static_shock/lib/src/plugins/drafting.dart
@@ -4,6 +4,22 @@ import 'package:static_shock/src/pages.dart';
 import 'package:static_shock/src/pipeline.dart';
 import 'package:static_shock/src/static_shock.dart';
 
+/// Plugin that helps with drafting content.
+///
+/// Drafting is the process of creating content over time. For example, an early version of an article
+/// might be written and committed, but that article shouldn't appear in the built website. With this
+/// plugin, that article can be marked as a draft, and it will be ignored in the website build.
+///
+/// To mark a [Page] as being a draft, set `draft` to `true` in the page configuration, e.g.,
+///
+/// ```
+/// ---
+/// title: My Article (WIP)
+/// draft: true
+/// ---
+/// ```
+///
+/// To preview draft content, build the website with [showDrafts] set to `true`.
 class DraftingPlugin implements StaticShockPlugin {
   const DraftingPlugin({
     this.showDrafts = false,
@@ -14,13 +30,13 @@ class DraftingPlugin implements StaticShockPlugin {
   @override
   FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
     pipeline.filterPages(
-      DraftPageFilter(showDrafts: showDrafts),
+      _DraftPageFilter(showDrafts: showDrafts),
     );
   }
 }
 
-class DraftPageFilter implements PageFilter {
-  const DraftPageFilter({
+class _DraftPageFilter implements PageFilter {
+  const _DraftPageFilter({
     this.showDrafts = false,
   });
 

--- a/packages/static_shock/lib/src/plugins/drafting.dart
+++ b/packages/static_shock/lib/src/plugins/drafting.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:static_shock/src/pages.dart';
+import 'package:static_shock/src/pipeline.dart';
+import 'package:static_shock/src/static_shock.dart';
+
+class DraftingPlugin implements StaticShockPlugin {
+  const DraftingPlugin({
+    this.showDrafts = false,
+  });
+
+  final bool showDrafts;
+
+  @override
+  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+    pipeline.filterPages(
+      DraftPageFilter(showDrafts: showDrafts),
+    );
+  }
+}
+
+class DraftPageFilter implements PageFilter {
+  const DraftPageFilter({
+    this.showDrafts = false,
+  });
+
+  final bool showDrafts;
+
+  @override
+  bool shouldInclude(StaticShockPipelineContext context, Page page) {
+    if (showDrafts) {
+      return true;
+    }
+
+    return page.data['draft'] != true;
+  }
+}

--- a/packages/static_shock/lib/src/plugins/menus.dart
+++ b/packages/static_shock/lib/src/plugins/menus.dart
@@ -1,0 +1,88 @@
+import 'package:static_shock/src/pipeline.dart';
+import 'package:yaml/yaml.dart';
+
+/// Returns `true` if the [YamlList] of menu items is either empty, or it only contains items
+/// for non-existent pages.
+///
+/// Returns `false` if the [YamlList] of menu items has at least one item for a page that exists.
+(String testName, Function testFunction) isMenuEmpty(StaticShockPipelineContext context) {
+  return (
+    "menuEmpty",
+    (YamlList menuItems, List<Object?> pathPrefixFragments) =>
+        !_isMenuNonEmpty(context, menuItems, pathPrefixFragments),
+  );
+}
+
+/// Returns `true` if the [YamlList] of menu items contains at least one item that corresponds to
+/// a [Page] that exists.
+///
+/// Returns `false` if the [YamlList] of menu items is empty, or if the menu only contains items for
+/// non-existent pages.
+(String testName, Function testFunction) isMenuNonEmpty(StaticShockPipelineContext context) {
+  return (
+    "menuNonEmpty",
+    (YamlList menuItems, List<Object?> pathPrefixFragments) => _isMenuNonEmpty(context, menuItems, pathPrefixFragments),
+  );
+}
+
+bool _isMenuNonEmpty(
+  StaticShockPipelineContext context,
+  YamlList menuItems,
+  List<Object?> prefixPathFragments,
+) {
+  if (menuItems.isEmpty) {
+    return false;
+  }
+
+  return _pageExistsForMenuItem(context, menuItems, prefixPathFragments).isNotEmpty;
+}
+
+/// A [StaticShockJinjaFilterBuilder] whose filter takes a list of YAML menu items
+/// and removes all the menu items for which no [Page] exists.
+///
+/// The following example adds a link for every menu item that has a corresponding page:
+///
+/// ```
+/// {% for menuItem in docs_menu|itemsForExistingPages(["guides"]) %}
+///   <a class="btn btn-primary btn-sm" href="/guides/{{ menuItem.id }}" role="button">{{ menuItem.title }}</a>
+/// {% endfor %}
+/// ```
+(String filterName, Function filterFunction) menuItemsWherePageExistsFilterBuilder(StaticShockPipelineContext context) {
+  return (
+    "itemsForExistingPages",
+    (YamlList menuItems, List<Object?> pathPrefixFragments) =>
+        _pageExistsForMenuItem(context, menuItems, pathPrefixFragments),
+  );
+}
+
+/// Filters out all menu items for which no [Page] currently exists.
+///
+/// This filter is especially useful when using draft mode because draft mode removes pages
+/// that exist in the source set, but happen to be marked as being in draft mode.
+///
+/// Path fragments are used instead of a full path because it's not always possible for Jinja
+/// template code to assemble interpolated strings. Therefore, fragments are used, for example:
+/// Given the fragments ["guides", "getting-started"], this method searches for
+/// a [Page] with the path "guides/getting-started/".
+YamlList _pageExistsForMenuItem(
+  StaticShockPipelineContext context,
+  YamlList menuItems,
+  List<Object?> prefixPathFragments,
+) {
+  final filteredMenuItems = <Object>[];
+  for (final menuItem in menuItems) {
+    final pathFragments = [...prefixPathFragments, menuItem['id']];
+    final url = "${pathFragments.join("/")}/";
+    print("Checking if menu item has a page with url: '$url'");
+    for (final page in context.pagesIndex.pages) {
+      print(" - existing page url: ${page.url}");
+      if (page.url == url) {
+        print("    - THIS IS THE PAGE");
+        filteredMenuItems.add(menuItem);
+        break;
+      }
+    }
+  }
+
+  return YamlList.wrap(filteredMenuItems);
+}

--- a/packages/static_shock/lib/static_shock.dart
+++ b/packages/static_shock/lib/static_shock.dart
@@ -12,7 +12,9 @@ export 'src/source_files.dart';
 export 'src/files.dart';
 
 // ----- Plugins -----
+export 'src/plugins/drafting.dart';
 export 'src/plugins/markdown.dart';
+export 'src/plugins/menus.dart';
 export 'src/plugins/jinja.dart';
 export 'src/plugins/pretty_urls.dart';
 export 'src/plugins/pub_package.dart';

--- a/packages/static_shock/pubspec.yaml
+++ b/packages/static_shock/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
+  collection: ^1.18.0
   fbh_front_matter: ^0.0.1
   jinja: ^0.4.2
   markdown: ^7.0.2

--- a/packages/static_shock_cli/bin/static_shock_cli.dart
+++ b/packages/static_shock_cli/bin/static_shock_cli.dart
@@ -92,9 +92,18 @@ class BuildCommand extends Command {
   final description = "Builds a Static Shock website when run at the top-level of a Static Shock project.";
 
   @override
+  final bool takesArguments = true;
+
+  @override
   Future<void> run() async {
     _log.info("Building a Static Shock website.");
-    await buildWebsite();
+    if (argResults?.rest.isNotEmpty == true) {
+      _log.detail("Passing extra arguments to the website builder: ${argResults!.rest.join(", ")}");
+    }
+
+    await buildWebsite(
+      appArguments: argResults?.rest ?? [],
+    );
   }
 }
 

--- a/packages/static_shock_cli/bin/static_shock_cli.dart
+++ b/packages/static_shock_cli/bin/static_shock_cli.dart
@@ -121,13 +121,22 @@ class ServeCommand extends Command with PubVersionCheck {
   final description = "Serves a pre-built Static Shock site via localhost.";
 
   @override
+  final bool takesArguments = true;
+
+  @override
   Future<void> run() async {
     await super.run();
 
     // Run a website build just in case the user has never built, or hasn't built recently.
     _log.info("Building website.");
     try {
-      final result = await buildWebsite();
+      if (argResults?.rest.isNotEmpty == true) {
+        _log.detail("Passing extra arguments to the website builder: ${argResults!.rest.join(", ")}");
+      }
+
+      final result = await buildWebsite(
+        appArguments: argResults?.rest ?? [],
+      );
       if (result == null) {
         _log.err("Failed to build website, therefore not starting the dev server.");
         return;

--- a/packages/static_shock_cli/lib/src/website_builder.dart
+++ b/packages/static_shock_cli/lib/src/website_builder.dart
@@ -5,12 +5,15 @@ import 'package:yaml/yaml.dart';
 
 /// Builds a static shock website from a source directory.
 ///
+/// Any provided [appArguments] will be forwarded to the `main` method of the website builder.
+///
 /// Expects to find a `pubspec.yaml` in the current directory.
 ///
 /// Expects to find a project name in the `pubspec.yaml`, which is then expected to lead
 /// to the executable file via `bin/[package_name].dart`.
 Future<int?> buildWebsite({
   Logger? log,
+  List<String> appArguments = const [],
   bool attachBuildProcessToStdIo = true,
 }) async {
   final pubspecFile = File("pubspec.yaml");
@@ -38,7 +41,7 @@ Future<int?> buildWebsite({
   log?.detail("Running Static Shock executable: ${executableFile.path}");
   final process = await Process.start(
     'dart',
-    [executableFile.path],
+    [executableFile.path, ...appArguments],
   );
 
   stdout.addStream(process.stdout);

--- a/packages/static_shock_cli/pubspec.lock
+++ b/packages/static_shock_cli/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -583,7 +583,7 @@ packages:
       path: "../static_shock"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   stream_channel:
     dependency: transitive
     description:

--- a/packages/static_shock_docs/bin/static_shock_docs.dart
+++ b/packages/static_shock_docs/bin/static_shock_docs.dart
@@ -12,7 +12,9 @@ Future<void> main(List<String> arguments) async {
     ))
     ..plugin(const PrettyUrlsPlugin())
     ..plugin(const SassPlugin())
-    ..plugin(const DraftingPlugin())
+    ..plugin(DraftingPlugin(
+      showDrafts: arguments.contains("preview"),
+    ))
     ..plugin(const PubPackagePlugin({
       "static_shock",
       "static_shock_cli",

--- a/packages/static_shock_docs/bin/static_shock_docs.dart
+++ b/packages/static_shock_docs/bin/static_shock_docs.dart
@@ -5,9 +5,14 @@ Future<void> main(List<String> arguments) async {
   final staticShock = StaticShock()
     ..pick(DirectoryPicker.parse("images"))
     ..plugin(const MarkdownPlugin())
-    ..plugin(const JinjaPlugin())
+    ..plugin(JinjaPlugin(
+      filters: [
+        menuItemsWherePageExistsFilterBuilder,
+      ],
+    ))
     ..plugin(const PrettyUrlsPlugin())
     ..plugin(const SassPlugin())
+    ..plugin(const DraftingPlugin())
     ..plugin(const PubPackagePlugin({
       "static_shock",
       "static_shock_cli",

--- a/packages/static_shock_docs/pubspec.lock
+++ b/packages/static_shock_docs/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -89,14 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   fbh_front_matter:
     dependency: transitive
     description:
@@ -129,14 +121,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.15.4"
   html_unescape:
     dependency: transitive
     description:
@@ -407,7 +391,7 @@ packages:
       path: "../static_shock"
       relative: true
     source: path
-    version: "0.0.1-dev.2"
+    version: "0.0.2"
   stream_channel:
     dependency: transitive
     description:

--- a/packages/static_shock_docs/source/_includes/layouts/guides.jinja
+++ b/packages/static_shock_docs/source/_includes/layouts/guides.jinja
@@ -30,7 +30,7 @@
       <div class="container">
         <div class="row">
           <nav class="col-3 d-none d-md-block">
-            {% for menuItem in docs_menu %}
+            {% for menuItem in docs_menu|itemsForExistingPages(["guides"]) %}
               <a class="btn btn-primary btn-sm" href="/guides/{{ menuItem.id }}" role="button">{{ menuItem.title }}</a>
             {% endfor %}
           </nav>

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -10,6 +10,8 @@ docs_menu:
     id: copy-assets
   - title: Compile Sass
     id: compile-sass
+  - title: Draft Articles
+    id: draft-articles
   - title: Use Remote CSS and JS
     id: use-remote-css-and-js
   - title: Create a Plugin

--- a/packages/static_shock_docs/source/guides/draft-articles.md
+++ b/packages/static_shock_docs/source/guides/draft-articles.md
@@ -1,0 +1,77 @@
+---
+title: Draft Articles
+tags: drafting
+---
+# Draft Articles
+When writing documentation, blog entries, or news articles, it's convenient to be able to work on
+those pages within the static site project, but without publishing those pages to the final build.
+The drafting plugin makes this possible.
+
+Add the drafting plugin to your project.
+
+```dart
+final staticShock = StaticShock()
+  ..plugin(DraftingPlugin());
+```
+
+The drafting plugin excludes all pages that are marked as drafts. To mark a page as a draft, set
+the property `draft` to `true`.
+
+```markdown
+---
+title: My Work In Progress
+draft: true
+---
+# My Work In Progress
+I'm still working on this!
+```
+
+You can still build a version of your website that includes the draft pages by configuring the
+plugin to show them.
+
+```dart
+final staticShock = StaticShock()
+  ..plugin(DraftingPlugin(showDrafts: true));
+```
+
+It may not be convenient to alter the `DraftingPlugin` code every time you want to switch to/from
+draft mode. You can leverage the application arguments to implement your own concept of a configurable
+preview mode. For example, you might update your `main.dart` file to do the following.
+
+```dart
+void main(List<String> arguments) {
+  final isPreviewMode = arguments.contains("preview");
+  
+  // Configure the static website generator.
+  final staticShock = StaticShock()
+    // other configuration...
+    ..plugin(
+      DraftingPlugin(
+        showDrafts: isPreviewMode,
+      ),
+    );
+
+  // Generate the static website.
+  await staticShock.generateSite();
+}
+```
+
+With the concept of a preview mode, enabled by a "preview" command-line option, you can make the
+decision about preview mode whenever you build or serve your website.
+
+```bash
+# Regular build.
+shock build
+
+# Build with draft pages.
+shock build preview
+
+# Regular server.
+shock serve
+
+# Serve with draft pages.
+shock serve preview
+```
+
+The use of "preview" as the command-line argument is arbitrary. You can use whatever term you'd like.
+You need to configure your `main()` method to honor whatever value you choose.


### PR DESCRIPTION
Added draft-mode plugin to remove page drafts, also added filters and tests to assemble menus based on page existence (Resolves #71)

This PR includes:
 * A new guide about draft mode
 * Exclusion of pages during build when a property called `draft` is `true` (can be turned off with the plugin config)
 * Jinja filters and tests that help construct menus in Jinja templates given that some pages might not exist
 * `shock build` and `shock serve` now pass on any extra arguments so that an app might implement the concept of a "preview" mode when building or serving