### PR TITLE
Publish table-of-contents data with every Markdown page.

### DIFF
--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -54,7 +54,7 @@ class MarkdownPageLoader implements PageLoader {
       markdown.content ?? "",
       data: {
         ...markdown.data,
-        "toc": _createTableOfContents(destinationPath.value, markdown.content ?? ""),
+        "tableOfContents": _createTableOfContents(destinationPath.value, markdown.content ?? ""),
       },
       destinationPath: destinationPath,
     );

--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -58,7 +58,7 @@ class MarkdownPageLoader implements PageLoader {
   }
 
   Map<String, dynamic> _createTableOfContents(String pageUrl, String markdown) {
-    final links = <Map<String, dynamic>>[];
+    final items = <Map<String, dynamic>>[];
     final lines = markdown.split("\n");
     bool ignoreCurrentBlock = false;
     for (final line in lines) {
@@ -96,7 +96,7 @@ class MarkdownPageLoader implements PageLoader {
       }
 
       if (level != null) {
-        links.add({
+        items.add({
           "title": title!,
           // The following section ID assignment applies the same ID naming convention as the Markdown
           // package. This is required, because the URL needs to link to the HTML header on this
@@ -110,12 +110,12 @@ class MarkdownPageLoader implements PageLoader {
     }
 
     return {
-      "links": links,
-      "isEmpty": links.isEmpty,
-      "isEmptyBeyondLevel": (int level) => _linkCountBeyondLevel(links, level) == 0,
-      "hasMultipleBeyondLevel": (int level) => _linkCountBeyondLevel(links, level) > 1,
-      "linkCountBeyondLevel": (int level) => _linkCountBeyondLevel(links, level),
-      "renderHtmlList": ({int? startingLevel}) => _renderHtmlList(links, startingLevel),
+      "items": items,
+      "isEmpty": items.isEmpty,
+      "isEmptyBeyondLevel": (int level) => _linkCountBeyondLevel(items, level) == 0,
+      "hasMultipleBeyondLevel": (int level) => _linkCountBeyondLevel(items, level) > 1,
+      "linkCountBeyondLevel": (int level) => _linkCountBeyondLevel(items, level),
+      "renderHtmlList": ({int? startingLevel}) => _renderHtmlList(items, startingLevel),
     };
   }
 

--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -44,9 +44,6 @@ class MarkdownPageLoader implements PageLoader {
       rethrow;
     }
 
-    print("Markdown content:");
-    print(markdown.content ?? "");
-
     final destinationPath = path.copyWith(extension: "html");
 
     return Page(
@@ -116,7 +113,7 @@ class MarkdownPageLoader implements PageLoader {
       "isEmptyBeyondLevel": (int level) => _linkCountBeyondLevel(links, level) == 0,
       "hasMultipleBeyondLevel": (int level) => _linkCountBeyondLevel(links, level) > 1,
       "linkCountBeyondLevel": (int level) => _linkCountBeyondLevel(links, level),
-      "renderMultiLevelList": ({int? startingLevel}) => _renderMultiLevelList(links, startingLevel),
+      "renderHtmlList": ({int? startingLevel}) => _renderHtmlList(links, startingLevel),
     };
   }
 
@@ -124,7 +121,7 @@ class MarkdownPageLoader implements PageLoader {
     return links.where((link) => link["level"] > level).fold(0, (prev, link) => prev + 1);
   }
 
-  String _renderMultiLevelList(List<Map<String, dynamic>> links, [int? startingLevel]) {
+  String _renderHtmlList(List<Map<String, dynamic>> links, [int? startingLevel]) {
     final visibleLinks = startingLevel == null ? links : links.where((link) => link["level"] >= startingLevel);
     if (visibleLinks.isEmpty) {
       return "";
@@ -135,21 +132,15 @@ class MarkdownPageLoader implements PageLoader {
       baseLevel = max(startingLevel, baseLevel);
     }
 
+    // Create a Markdown list of links for every header. We'll convert it to HTML next.
     final tocMarkdown = StringBuffer();
     for (final link in visibleLinks) {
       final indent = List.generate((link["level"] - baseLevel), (index) => "  ").join("");
       tocMarkdown.writeln("${indent}1. [${link["title"]}](${link["url"]})");
     }
 
-    print("Table of contents rendered list:");
-    print(tocMarkdown.toString());
-
-    final html = markdownToHtml(tocMarkdown.toString());
-    print("---");
-    print("HTML version:");
-    print(html);
-
-    return html;
+    // Convert the markdown link list to an HTML list, which can be used as a table of contents.
+    return markdownToHtml(tocMarkdown.toString());
   }
 }
 

--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -98,10 +98,12 @@ class MarkdownPageLoader implements PageLoader {
       if (level != null) {
         links.add({
           "title": title!,
-          // The following title assignment applies the same ID naming convention as the Markdown
+          // The following section ID assignment applies the same ID naming convention as the Markdown
           // package. This is required, because the URL needs to link to the HTML header on this
           // page, which was created by the Markdown parser.
-          "url": "#${title.toLowerCase().replaceAll(" ", "-")}",
+          //
+          // Example: "#my-section-title"
+          "sectionId": "#${title.toLowerCase().replaceAll(" ", "-")}",
           "level": level,
         });
       }
@@ -136,7 +138,7 @@ class MarkdownPageLoader implements PageLoader {
     final tocMarkdown = StringBuffer();
     for (final link in visibleLinks) {
       final indent = List.generate((link["level"] - baseLevel), (index) => "  ").join("");
-      tocMarkdown.writeln("${indent}1. [${link["title"]}](${link["url"]})");
+      tocMarkdown.writeln("${indent}1. [${link["title"]}](${link["sectionId"]})");
     }
 
     // Convert the markdown link list to an HTML list, which can be used as a table of contents.

--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:fbh_front_matter/fbh_front_matter.dart' as front_matter;
 import 'package:markdown/markdown.dart';
@@ -43,12 +44,112 @@ class MarkdownPageLoader implements PageLoader {
       rethrow;
     }
 
+    print("Markdown content:");
+    print(markdown.content ?? "");
+
+    final destinationPath = path.copyWith(extension: "html");
+
     return Page(
       path,
       markdown.content ?? "",
-      data: {...markdown.data},
-      destinationPath: path.copyWith(extension: "html"),
+      data: {
+        ...markdown.data,
+        "toc": _createTableOfContents(destinationPath.value, markdown.content ?? ""),
+      },
+      destinationPath: destinationPath,
     );
+  }
+
+  Map<String, dynamic> _createTableOfContents(String pageUrl, String markdown) {
+    final links = <Map<String, dynamic>>[];
+    final lines = markdown.split("\n");
+    bool ignoreCurrentBlock = false;
+    for (final line in lines) {
+      if (line == "```" || (line.startsWith("```") && !line.endsWith("```"))) {
+        // This line either starts or ends a code block. We want to ignore all content
+        // in code blocks so that we don't add lines of code to the table of contents.
+        ignoreCurrentBlock = !ignoreCurrentBlock;
+      }
+
+      if (ignoreCurrentBlock) {
+        continue;
+      }
+
+      int? level;
+      String? title;
+
+      if (line.startsWith("# ")) {
+        level = 0;
+        title = line.substring(2);
+      } else if (line.startsWith("## ")) {
+        level = 1;
+        title = line.substring(3);
+      } else if (line.startsWith("### ")) {
+        level = 2;
+        title = line.substring(4);
+      } else if (line.startsWith("#### ")) {
+        level = 3;
+        title = line.substring(5);
+      } else if (line.startsWith("##### ")) {
+        level = 4;
+        title = line.substring(6);
+      } else if (line.startsWith("###### ")) {
+        level = 5;
+        title = line.substring(7);
+      }
+
+      if (level != null) {
+        links.add({
+          "title": title!,
+          // The following title assignment applies the same ID naming convention as the Markdown
+          // package. This is required, because the URL needs to link to the HTML header on this
+          // page, which was created by the Markdown parser.
+          "url": "#${title.toLowerCase().replaceAll(" ", "-")}",
+          "level": level,
+        });
+      }
+    }
+
+    return {
+      "links": links,
+      "isEmpty": links.isEmpty,
+      "isEmptyBeyondLevel": (int level) => _linkCountBeyondLevel(links, level) == 0,
+      "hasMultipleBeyondLevel": (int level) => _linkCountBeyondLevel(links, level) > 1,
+      "linkCountBeyondLevel": (int level) => _linkCountBeyondLevel(links, level),
+      "renderMultiLevelList": ({int? startingLevel}) => _renderMultiLevelList(links, startingLevel),
+    };
+  }
+
+  int _linkCountBeyondLevel(List<Map<String, dynamic>> links, int level) {
+    return links.where((link) => link["level"] > level).fold(0, (prev, link) => prev + 1);
+  }
+
+  String _renderMultiLevelList(List<Map<String, dynamic>> links, [int? startingLevel]) {
+    final visibleLinks = startingLevel == null ? links : links.where((link) => link["level"] >= startingLevel);
+    if (visibleLinks.isEmpty) {
+      return "";
+    }
+
+    int baseLevel = visibleLinks.fold(6, (prev, link) => link["level"] < prev ? link["level"] : prev);
+    if (startingLevel != null) {
+      baseLevel = max(startingLevel, baseLevel);
+    }
+
+    final tocMarkdown = StringBuffer();
+    for (final link in visibleLinks) {
+      final indent = List.generate((link["level"] - baseLevel), (index) => "  ").join("");
+      tocMarkdown.writeln("${indent}1. [${link["title"]}](${link["url"]})");
+    }
+
+    print("Table of contents rendered list:");
+    print(tocMarkdown.toString());
+
+    final html = markdownToHtml(tocMarkdown.toString());
+    print("---");
+    print("HTML version:");
+    print(html);
+
+    return html;
   }
 }
 
@@ -65,7 +166,12 @@ class MarkdownPageRenderer implements PageRenderer {
     }
 
     _log.detail("Transforming Markdown page: ${page.sourcePath}");
-    final contentHtml = markdownToHtml(page.sourceContent);
+    final contentHtml = markdownToHtml(
+      page.sourceContent,
+      blockSyntaxes: [
+        HeaderWithIdSyntax(),
+      ],
+    );
     page.destinationContent = contentHtml;
   }
 }

--- a/packages/static_shock_docs/source/_includes/layouts/guides.jinja
+++ b/packages/static_shock_docs/source/_includes/layouts/guides.jinja
@@ -39,7 +39,7 @@
 
             {% if tableOfContents is defined and tableOfContents.linkCountBeyondLevel(0) > 1 %}
             <div class="table-of-contents">
-            {{ tableOfContents.renderMultiLevelList(startingLevel = 1) }}
+            {{ tableOfContents.renderHtmlList(startingLevel = 1) }}
             </div>
 
             <div class="table-of-contents-divider">&nbsp;</div>

--- a/packages/static_shock_docs/source/_includes/layouts/guides.jinja
+++ b/packages/static_shock_docs/source/_includes/layouts/guides.jinja
@@ -42,7 +42,7 @@
             {{ tableOfContents.renderMultiLevelList(startingLevel = 1) }}
             </div>
 
-            <div class="toc-divider">&nbsp;</div>
+            <div class="table-of-contents-divider">&nbsp;</div>
             {% endif %}
 
 

--- a/packages/static_shock_docs/source/_includes/layouts/guides.jinja
+++ b/packages/static_shock_docs/source/_includes/layouts/guides.jinja
@@ -35,6 +35,17 @@
             {% endfor %}
           </nav>
           <section class="col-md-9 col-12">
+            <h1>{{ title }}</h1>
+
+            {% if toc is defined and toc.linkCountBeyondLevel(0) > 1 %}
+            <div class="table-of-contents">
+            {{ toc.renderMultiLevelList(startingLevel = 1) }}
+            </div>
+
+            <div class="toc-divider">&nbsp;</div>
+            {% endif %}
+
+
             {{ content }}
           </section>
         </div>

--- a/packages/static_shock_docs/source/_includes/layouts/guides.jinja
+++ b/packages/static_shock_docs/source/_includes/layouts/guides.jinja
@@ -37,9 +37,9 @@
           <section class="col-md-9 col-12">
             <h1>{{ title }}</h1>
 
-            {% if toc is defined and toc.linkCountBeyondLevel(0) > 1 %}
+            {% if tableOfContents is defined and tableOfContents.linkCountBeyondLevel(0) > 1 %}
             <div class="table-of-contents">
-            {{ toc.renderMultiLevelList(startingLevel = 1) }}
+            {{ tableOfContents.renderMultiLevelList(startingLevel = 1) }}
             </div>
 
             <div class="toc-divider">&nbsp;</div>

--- a/packages/static_shock_docs/source/guides/add-a-page.md
+++ b/packages/static_shock_docs/source/guides/add-a-page.md
@@ -2,7 +2,6 @@
 title: Add a Page
 tags: drafting
 ---
-# Add a Page
 A page is a URL-addressable web page.
 
 A page can be configured with a Markdown file, which is the most common approach for repeated content, such as blog posts. A page can also be configured with a Jinja template, which is the most common approach for one-off pages, such as a landing page, or a contact page. 

--- a/packages/static_shock_docs/source/guides/compile-sass.md
+++ b/packages/static_shock_docs/source/guides/compile-sass.md
@@ -2,7 +2,6 @@
 title: Compile Sass
 tags: styling
 ---
-# Compile Sass
 Sass (also known as SCSS) is a format for defining CSS in a more convenient and extensible way.
 
 Sass is a CSS superset, which means you can write regular CSS in a Sass file. But, Sass adds a 

--- a/packages/static_shock_docs/source/guides/copy-assets.md
+++ b/packages/static_shock_docs/source/guides/copy-assets.md
@@ -2,7 +2,6 @@
 title: Copy Assets
 tags: drafting
 ---
-# Copy Images, CSS, JS
 A static site typically contains many assets. An asset is a file served by a web server, which isn't a page.
 
 Typically an asset, like an image, should be copied directly from the source set to the build set.

--- a/packages/static_shock_docs/source/guides/create-a-plugin.md
+++ b/packages/static_shock_docs/source/guides/create-a-plugin.md
@@ -2,8 +2,6 @@
 title: Create a Plugin
 tags: extensions
 ---
-# Create a Plugin
-
 ## What is a plugin?
 A plugin is a collection of Static Shock configurations that's easy to share across projects and
 across the community. For example, a plugin might pick specific files for the pipeline, apply

--- a/packages/static_shock_docs/source/guides/create-rss-feed.md
+++ b/packages/static_shock_docs/source/guides/create-rss-feed.md
@@ -2,8 +2,6 @@
 title: Create RSS Feed
 tags: publishing
 ---
-# Create RSS Feed
-
 <div class="alert alert-danger" role="alert">
   TODO: Implement an RSS plugin
 </div>

--- a/packages/static_shock_docs/source/guides/deploy-to-github-pages.md
+++ b/packages/static_shock_docs/source/guides/deploy-to-github-pages.md
@@ -2,7 +2,6 @@
 title: Deploy to GitHub Pages
 tags: publishing
 ---
-# GitHub Pages
 GitHub provides a free tool for building, deploying, and serving static websites - it's called
 [GitHub Pages](https://pages.github.com/).
 

--- a/packages/static_shock_docs/source/guides/directory-of-pages.md
+++ b/packages/static_shock_docs/source/guides/directory-of-pages.md
@@ -2,7 +2,6 @@
 title: Directory of Pages
 tags: drafting
 ---
-# Directory of Pages
 Use the pages index to display a list of page links for pages in your website.
 
 ## List all pages

--- a/packages/static_shock_docs/source/guides/display-a-menu-in-a-page.md
+++ b/packages/static_shock_docs/source/guides/display-a-menu-in-a-page.md
@@ -2,7 +2,6 @@
 title: Display a Menu in a Page
 tags: drafting
 ---
-# Display a Menu in a Page
 A page might display a menu of links, and it might appear as if the content changes within that
 one page when you select different menu items. For example, the page you're viewing right now
 contains a menu with links to different guides. However, you're not looking at one single page,

--- a/packages/static_shock_docs/source/guides/draft-articles.md
+++ b/packages/static_shock_docs/source/guides/draft-articles.md
@@ -2,7 +2,6 @@
 title: Draft Articles
 tags: drafting
 ---
-# Draft Articles
 When writing documentation, blog entries, or news articles, it's convenient to be able to work on
 those pages within the static site project, but without publishing those pages to the final build.
 The drafting plugin makes this possible.

--- a/packages/static_shock_docs/source/guides/use-remote-css-and-js.md
+++ b/packages/static_shock_docs/source/guides/use-remote-css-and-js.md
@@ -1,7 +1,6 @@
 ---
 title: Use Remote CSS and JS
 ---
-# Use Remote CSS and JS
 <div class="alert alert-danger" role="alert">
   TODO: Create pipeline hooks to pick up remote file references
 </div>

--- a/packages/static_shock_docs/source/styles/guides.scss
+++ b/packages/static_shock_docs/source/styles/guides.scss
@@ -4,6 +4,48 @@ h1 {
   color: $accent;
 }
 
+h2, p + h2 {
+  margin-top: 2em;
+}
+
+h3, h4, h5, h6 {
+  margin-top: 1.5em;
+}
+
+p {
+  line-height: 1.8em;
+}
+
+.table-of-contents {
+  margin-top: 3em;
+  margin-bottom: 3em;
+
+  li {
+    margin-bottom: 0.5em;
+    padding-left: 12px;
+
+    & > a {
+      color: $defaultTextColor;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+.toc-divider {
+  display: block;
+
+  margin-top: 24px;
+  margin-bottom: 24px;
+
+  width: 100%;
+  height: 1px;
+
+  background: rgba(255, 255, 255, 0.05);
+}
+
 .btn {
   display: block;
 

--- a/packages/static_shock_docs/source/styles/guides.scss
+++ b/packages/static_shock_docs/source/styles/guides.scss
@@ -34,7 +34,7 @@ p {
   }
 }
 
-.toc-divider {
+.table-of-contents-divider {
   display: block;
 
   margin-top: 24px;

--- a/packages/static_shock_docs/source/styles/theme.scss
+++ b/packages/static_shock_docs/source/styles/theme.scss
@@ -52,7 +52,7 @@ code {
 //   margin-bottom: 2em;
 //
 //   padding: 5em 3em;
-
+//
 //   background: rgb(207,36,36);
 //   background: linear-gradient(331deg, rgba(207,36,36,1) 0%, rgba(255,182,143,1) 100%);
 // }

--- a/packages/static_shock_docs/source/styles/theme.scss
+++ b/packages/static_shock_docs/source/styles/theme.scss
@@ -11,6 +11,7 @@ $primaryLighter : #203035;
 $accent       : #FFE500;
 $accentLight  : #FFFF33;
 
+$defaultTextColor: WHITE;
 $inlineCode : $accent;
 
 @font-face {
@@ -25,10 +26,13 @@ $inlineCode : $accent;
 }
 
 html, body {
-  color: WHITE;
+  color: $defaultTextColor;
 
   font-size: 20px;
-  height: 1.4em;
+}
+
+p {
+  line-height: 1.4em;
 }
 
 .accent-text {
@@ -48,7 +52,7 @@ code {
 //   margin-bottom: 2em;
 //
 //   padding: 5em 3em;
-//
+
 //   background: rgb(207,36,36);
 //   background: linear-gradient(331deg, rgba(207,36,36,1) 0%, rgba(255,182,143,1) 100%);
 // }


### PR DESCRIPTION
Publish table-of-contents data with every Markdown page.

The Markdown plugin adds root level data to the `Page` data structure with the key "tableOfContents".

Example of "tableOfContents" data, accessible from templates:

```
"tableOfContents": {
  "items": [{
    "title": "...",
    "sectionId": "...",
    "level": 0,
  }],
  "isEmpty": false,
  "isEmptyBeyondLevel": (level) => {},
  "hasMultipleBeyondLevel": (level) => {},
  "linkCountBeyondLevel": (level) => {},
  "renderHtmlList": ({startingLevel}) => {},
}
```