### PR TITLE
Allow basePath override for pages (Resolves #88)

### DIFF
--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -350,6 +350,12 @@ class StaticShock implements StaticShockPipeline {
         final inheritedData = _dataIndex.getForPath(page.sourcePath);
         page.data.addEntries(inheritedData.entries);
 
+        // Check for a desired base path override, and apply it.
+        final basePath = page.data['basePath'] as String?;
+        if (basePath != null && basePath.isNotEmpty) {
+          page.destinationPath = page.destinationPath!.copyWith(directoryPath: basePath);
+        }
+
         _pages.add(page);
 
         continue pickerLoop;

--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -351,8 +351,18 @@ class StaticShock implements StaticShockPipeline {
         page.data.addEntries(inheritedData.entries);
 
         // Check for a desired base path override, and apply it.
-        final basePath = page.data['basePath'] as String?;
+        String? basePath = page.data['basePath'];
         if (basePath != null && basePath.isNotEmpty) {
+          if (basePath.startsWith("/")) {
+            // Chop off leading "/".
+            //
+            // A "/" is acceptable from a URL perspective, where it refers to the root
+            // of the website. However, from a file system perspective, a "/" refers to
+            // the root of the file system. We don't want to write files to the root of
+            // the file system.
+            basePath = basePath.substring(1);
+          }
+
           page.destinationPath = page.destinationPath!.copyWith(directoryPath: basePath);
         }
 

--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -363,6 +363,7 @@ class StaticShock implements StaticShockPipeline {
             basePath = basePath.substring(1);
           }
 
+          _log.detail("Overriding default page URL:\nFrom: ${page.destinationPath?.value}\nTo: $basePath");
           page.destinationPath = page.destinationPath!.copyWith(directoryPath: basePath);
         }
 

--- a/packages/static_shock_docs/source/guides/add-a-page.md
+++ b/packages/static_shock_docs/source/guides/add-a-page.md
@@ -106,3 +106,21 @@ Continuing with our example, after running a Static Shock build, an HTML file is
 ```
 
 You now have a static HTML page that you can serve to users, and it's available at your desired URL path.
+
+## Change the base path of the URL
+For many websites, the source directory structure works well for the final URL, such as `/guides/getting-started.md`
+being deployed to `mysite.com/guides/getting-started/`. However, for some websites, the best directory
+structure doesn't necessarily match the desired URL. For example, a blog might store a post at 
+`/posts/my-post.md` but the blog author would like to serve that post at `myblog.com/my-post/`.
+
+Static Shock allows you to override the base path of the final URL. The base path is the path that
+appears before the final path segment, e.g., given `/posts/my-post/` the base path is `/posts`. To
+override the default base path, specify a different value for `basePath` for a given page, or
+within a `_data.yaml` file to apply the change to entire directory.
+
+```markdown
+---
+title: My Blog Post
+basePath: /
+---
+```

--- a/packages/static_shock_docs/source/guides/directory-of-pages.md
+++ b/packages/static_shock_docs/source/guides/directory-of-pages.md
@@ -35,7 +35,7 @@ tags:
 # My Page
 ```
 
-You can also defin tags in the front matter for Jinja pages.
+You can also define tags in the front matter for Jinja pages.
 
 ```html
 <!--
@@ -62,4 +62,19 @@ After associating pages with tags, list pages per tag by using the tag iterator 
     {% endfor %}
   </body>
 </html>
+```
+
+## Hide a page from the index
+Sometimes you might want a page to be available at a URL, but you don't want that page to be listed
+in a directory of pages. For example, perhaps you published an article that you no longer want to
+promote, but you want the URL to keep working for existing links around the web.
+
+You can hide individual pages from the page index, while still publishing them to a URL, by using
+the `shouldIndex` page property.
+
+```yaml
+---
+title: My Hidden Page
+shouldIndex: false
+---
 ```


### PR DESCRIPTION
Allow basePath override for pages (Resolves #88)

Given a directory page like "/guides/pages/create-page.md" the base path is "/guides/pages". This PR introduces a property called `basePath`, which can be set for a page, and it replaces the default directory structure base path.

The property can be provided in a `_data.yaml` at a directory level to make it apply to the entire directory.

This PR also adds a guide for this `basePath` feature, as well as for hiding individual pages, which was implemented in #86 