### PR TITLE
Added a 'formatDateTime' Jinja filter to format incoming date times (Resolves #90)

### DIFF
--- a/packages/static_shock/lib/src/plugins/jinja.dart
+++ b/packages/static_shock/lib/src/plugins/jinja.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:intl/intl.dart';
 import 'package:jinja/jinja.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:static_shock/src/files.dart';
@@ -134,6 +135,7 @@ class JinjaPageRenderer implements PageRenderer {
   void _renderJinjaToContent(StaticShockPipelineContext context, Page page, String templateSource) {
     final jinjaFilters = Map.fromEntries([
       MapEntry("startsWith", _startsWith),
+      MapEntry("formatDateTime", _formatDateTime),
       ...filters.map((filterBuilder) {
         final filter = filterBuilder(context);
         return MapEntry<String, Function>(filter.$1, filter.$2);
@@ -204,5 +206,23 @@ class JinjaPageRenderer implements PageRenderer {
       return false;
     }
     return candidate.startsWith(prefix);
+  }
+
+  /// Jinja filter that formats an incoming date string.
+  ///
+  /// The incoming format defaults to "yyyy-MM-dd", but an alternative
+  /// incoming format can be provided in [from].
+  ///
+  /// The returned date string follows the [to] format, which is required.
+  ///
+  /// This filter might be used, for example, to replace "2024-02-15" with
+  /// "Feb 15, 2024".
+  String _formatDateTime(
+    String date, {
+    String from = "yyyy-MM-dd",
+    required String to,
+  }) {
+    final dateTime = DateFormat(from).parse(date);
+    return DateFormat(to).format(dateTime);
   }
 }

--- a/packages/static_shock/pubspec.yaml
+++ b/packages/static_shock/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   fbh_front_matter: ^0.0.1
+  intl: ^0.19.0
   jinja: ^0.4.2
   markdown: ^7.0.2
   mason_logger: ^0.2.5


### PR DESCRIPTION
Added a 'formatDateTime' Jinja filter to format incoming date times (Resolves #90)

Example: `{{ date | formatDateTime(to = "MMMM dd, yyyy") }}`