### PR TITLE
Automatically initialize project after creation (Resolves #98)

### DIFF
--- a/packages/static_shock_cli/bin/static_shock_cli.dart
+++ b/packages/static_shock_cli/bin/static_shock_cli.dart
@@ -45,7 +45,27 @@ class CreateCommand extends Command with PubVersionCheck {
 
     await generator.generate(target, vars: projectConfiguration);
 
-    _log.success("Successfully created a new Static Shock project!");
+    _log.success("Successfully created a new Static Shock project!\n");
+
+    _log.info("Running 'pub get' to initialize your project...");
+    final pubGetResult = await Process.run('dart', ['pub', 'get']);
+    _log.detail(pubGetResult.stdout);
+    if (pubGetResult.exitCode != 0) {
+      _log.err("Command 'pub get' failed. Please check your project for errors.");
+      return;
+    }
+
+    _log.info("Successfully initialized your project. Now we'll run an initial build of your static site.");
+    final buildResult = await Process.run('dart', ['run', 'bin/${projectConfiguration['project_name']}.dart']);
+    _log.detail(buildResult.stdout);
+    if (buildResult.exitCode != 0) {
+      _log.err("Failed to build your static site. Please check your project for errors.");
+      return;
+    }
+
+    _log.success("Congratulations, your Static Shock project is ready to go!");
+
+    _log.info("\nTo learn how to use Static Shock, check out staticshock.io\n");
   }
 
   Future<Map<String, dynamic>> _promptForConfiguration() async {


### PR DESCRIPTION
Automatically initialize project after creation (Resolves #98)

Every Static Shock project needs to call dart pub get before it can run a build. This isn't obvious to the average user, so we should run it immediately after project creation.

Also, we should automatically run a static site build after creating the project, too. That way the user is in the ideal position to begin creating content.

This PR runs `dart pub get` and then `dart run bin/{project}.dart` after creating the project.