### PR TITLE
Fix recurring dev server crashes (Resolves #76)

### DIFF
--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -153,16 +153,14 @@ class StaticShockDevServer {
       _connectedWebpages.add(webSocket);
 
       webSocket.stream.listen((message) {
-        final log = Logger(level: Level.verbose);
-        log.detail("Page websocket received message: '$message'");
+        _log.detail("Page websocket received message: '$message'");
         webSocket.sink.add("echo $message");
       });
 
       webSocket.sink.done.then((webSocketImpl) {
         // Note: The "web socket" we're given in this callback is of type WebSocketImpl, which is
         // different from the WebSocketChannel type that we receive in the main callback above.
-        final log = Logger(level: Level.verbose);
-        log.detail("WebSocket is done! Removing it: $webSocket - ID: ${webSocket.hashCode}");
+        _log.detail("WebSocket is done! Removing it: $webSocket - ID: ${webSocket.hashCode}");
         _connectedWebpages.remove(webSocket);
       });
     });

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   mason_logger: ^0.2.12
   shelf: ^1.4.1
   shelf_static: ^1.1.2
-  pub_updater: ^0.4.0
+  pub_updater: any
   yaml: ^3.1.2
   watcher: ^1.1.0
   html: ^0.15.4

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -10,7 +10,7 @@ executables:
   shock: static_shock_cli
 
 dependencies:
-  static_shock: ^0.0.1
+  static_shock: ^0.0.3
 
   args: ^2.4.0
   cli_completion: ^0.3.0


### PR DESCRIPTION
Fix recurring dev server crashes (Resolves #76)

My hypothesis is that we were running into race conditions when accessing the file system between the website build behavior and the websites refreshing their files. This PR waits until all queued builds are complete before telling connected websites to refresh.