### PR TITLE
Fix recurring dev server crashes (Resolves #76)

### DIFF
--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -153,16 +153,14 @@ class StaticShockDevServer {
       _connectedWebpages.add(webSocket);
 
       webSocket.stream.listen((message) {
-        final log = Logger(level: Level.verbose);
-        log.detail("Page websocket received message: '$message'");
+        _log.detail("Page websocket received message: '$message'");
         webSocket.sink.add("echo $message");
       });
 
       webSocket.sink.done.then((webSocketImpl) {
         // Note: The "web socket" we're given in this callback is of type WebSocketImpl, which is
         // different from the WebSocketChannel type that we receive in the main callback above.
-        final log = Logger(level: Level.verbose);
-        log.detail("WebSocket is done! Removing it: $webSocket - ID: ${webSocket.hashCode}");
+        _log.detail("WebSocket is done! Removing it: $webSocket - ID: ${webSocket.hashCode}");
         _connectedWebpages.remove(webSocket);
       });
     });

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   mason_logger: ^0.2.12
   shelf: ^1.4.1
   shelf_static: ^1.1.2
-  pub_updater: ^0.4.0
+  pub_updater: any
   yaml: ^3.1.2
   watcher: ^1.1.0
   html: ^0.15.4

--- a/packages/static_shock_cli/pubspec.yaml
+++ b/packages/static_shock_cli/pubspec.yaml
@@ -10,7 +10,7 @@ executables:
   shock: static_shock_cli
 
 dependencies:
-  static_shock: ^0.0.1
+  static_shock: ^0.0.3
 
   args: ^2.4.0
   cli_completion: ^0.3.0


### PR DESCRIPTION
Fix recurring dev server crashes (Resolves #76)

As best I can tell, the crashes are due to the file system being accessed by the website builder, while simultaneously being accessed by the web server. 

This PR changes when the connected websites are told to refresh themselves. We now wait until all queued builds are done before notifying them.

If the user manually refreshes during a rebuild, we probably have the same issue, but that should be far less common.

This PR also loosens the dependency on `pub_updater` to `any` because `static_shock` also has a dependency on `pub_updater` and it's too easy to end up with conflicting versions. 