### PR TITLE
[static_shock_cli]: Handle SocketException when checking for Pub version (resolves #128)

### DIFF
--- a/packages/static_shock_cli/lib/src/version_check.dart
+++ b/packages/static_shock_cli/lib/src/version_check.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -20,8 +22,13 @@ mixin PubVersionCheck on Command {
 
   @override
   Future<void> run() async {
-    final isUpToDate = await StaticShockCliVersion.isAtLeastUpToDateWithPub();
-    if (isUpToDate) {
+    try {
+      final isUpToDate = await StaticShockCliVersion.isAtLeastUpToDateWithPub();
+      if (isUpToDate) {
+        return;
+      }
+    } on SocketException {
+      log.warn('Unable to reach pub.dev. Skipping version check.');
       return;
     }
 


### PR DESCRIPTION
Handle `SocketException` when checking for Pub version.

`static_shock_cli` checks for a newer version of the package on `pub.dev` when running `shock serve`. It assumes that the user has an active internet connection, but this is not always the case.

While making a GET request when there is no internet connect, the `http` library defines and throws a `ClientException`. At a lower level, this is a `dart:io SocketException`. In order to avoid importing `http`, this PR just handles `SocketException`.

When a `SocketException` occurs, the code cancels the Pub check and logs a warning. This allows `static_shock_cli` to continue serving the site using the current local version. The alternative would be to abort the serve and tell the user to restore the internet connection. However, that would make for a bad user experience.

## Issues to consider

- This PR does not include a test. I didn't see any related tests for this type of functionality, and I'm uncertain how I would mock `StaticShockCliVersion` to test it.
- `UpgradeCommand` and `VersionCommand` also check for Pub version updates. I didn't update the code there since that is outside of the scope of issue #128. However, at least `VersionCommand` should also handle socket exceptions.