### PR TITLE
[Shock] - Expose all Markdown-to-HTML render options at plugin level. Also notify user if a page has unknown renderer.

### DIFF
--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -511,13 +511,21 @@ class StaticShock implements StaticShockPipeline {
     // Render the content for every page.
     _log.info("\nRendering content for all pages...");
     for (final page in _context.pagesIndex.pages) {
+      var didRender = false;
       for (final rendererId in page.contentRenderers) {
         for (final renderer in _pageRenderers) {
           if (renderer.id == rendererId) {
             _log.detail("Rendering page '${page.title}' content as '$rendererId'");
+            didRender = true;
             await renderer.renderContent(_context, page);
           }
         }
+      }
+
+      if (!didRender) {
+        _log.warn(
+          "Couldn't find any content renderers for page '${page.title}' - requested renderers: ${page.contentRenderers}",
+        );
       }
     }
     _timer.checkpoint(


### PR DESCRIPTION
[Shock] - Expose all Markdown-to-HTML render options at plugin level. Also notify user if a page has unknown renderer.

The impetus for the Markdown rendering options is that I was trying to get a page to render a combination of Markdown and Jinja, but the Markdown renderer kept escaping characters in the Jinja syntax. The setting for escaping characters is available at the point of requesting a Markdown-to-HTML conversion. All of those options are now elevated to the plugin level.

I also accidentally used the wrong syntax for specifying multiple renderers. I couldn't figure out why the page wasn't rendering. To help with that in the future, I added a warning when a page is loaded but fails to find at least one page renderer.