### PR TITLE
Added plugin for Tailwind CSS (Resolves #145)

### DIFF
--- a/packages/static_shock/lib/src/plugins/tailwind_css.dart
+++ b/packages/static_shock/lib/src/plugins/tailwind_css.dart
@@ -85,7 +85,8 @@ class _TailwindGenerator implements Finisher {
         ["-i", input, "-o", output],
       );
       if (result.exitCode != 0) {
-        context.log.warn("Failed to run Tailwind CSS compilation - exist code: ${result.exitCode}");
+        context.log.warn("Failed to run Tailwind CSS compilation - exit code: ${result.exitCode}");
+        context.log.warn(result.stderr);
         return;
       }
 

--- a/packages/static_shock/lib/src/plugins/tailwind_css.dart
+++ b/packages/static_shock/lib/src/plugins/tailwind_css.dart
@@ -11,8 +11,8 @@ import 'package:static_shock/src/static_shock.dart';
 /// website project directory.
 ///
 /// Learn more about the standalone Tailwind tool: https://tailwindcss.com/blog/standalone-cli
-class TailwindPlugin extends StaticShockPlugin {
-  TailwindPlugin({
+class TailwindPlugin implements StaticShockPlugin {
+  const TailwindPlugin({
     this.tailwindPath = "./tailwind",
     required this.input,
     required this.output,

--- a/packages/static_shock/lib/src/plugins/tailwind_css.dart
+++ b/packages/static_shock/lib/src/plugins/tailwind_css.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:static_shock/src/finishers.dart';
+import 'package:static_shock/src/pipeline.dart';
+import 'package:static_shock/src/static_shock.dart';
+
+/// [StaticShockPlugin] that runs Tailwind CSS against the project's source files.
+///
+/// This plugin depends on the presence of the Tailwind binary tool. By default,
+/// that tool is expected to be named `tailwind` and to sit at the root of the
+/// website project directory.
+///
+/// Learn more about the standalone Tailwind tool: https://tailwindcss.com/blog/standalone-cli
+class TailwindPlugin extends StaticShockPlugin {
+  TailwindPlugin({
+    this.tailwindPath = "./tailwind",
+    required this.input,
+    required this.output,
+  });
+
+  /// Path and name of the Tailwind executable.
+  final String tailwindPath;
+
+  /// File path to the Tailwind input file, which contains Tailwind code.
+  ///
+  /// Unlike typical CSS, there only needs to be a single input file for
+  /// Tailwind, and that file is mostly (or entirely) a configuration of
+  /// Tailwind, itself. For example, the following might be used as the
+  /// content of a file at `/styles/tailwind.css`.
+  ///
+  /// ```
+  /// @tailwind base;
+  /// @tailwind components;
+  /// @tailwind utilities;
+  /// ```
+  final String input;
+
+  /// File path to the desired Tailwind output file, where Tailwind
+  /// should write the compiled CSS.
+  ///
+  /// In general, this output file holds all styles for your website.
+  /// You might choose to place it at `/styles/styles.css` in the
+  /// build output directory. Any HTML file that wants to use these
+  /// styles need to reference this output stylesheet file location.
+  ///
+  /// ```
+  ///<link href="styles/styles.css" rel="stylesheet">
+  /// ```
+  final String output;
+
+  @override
+  void configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+    pipeline.finish(_TailwindGenerator(
+      tailwindPath: tailwindPath,
+      input: input,
+      output: output,
+    ));
+  }
+}
+
+class _TailwindGenerator implements Finisher {
+  const _TailwindGenerator({
+    required this.tailwindPath,
+    required this.input,
+    required this.output,
+  });
+
+  /// Path and name of the Tailwind executable.
+  final String tailwindPath;
+
+  /// File path to the input file, which contains Tailwind code.
+  final String input;
+
+  /// File path to the output file, where Tailwind should write the compiled CSS.
+  final String output;
+
+  @override
+  Future<void> execute(StaticShockPipelineContext context) async {
+    try {
+      context.log.info("Generating Tailwind CSS");
+      context.log.detail("Tailwind input file: $input");
+      final result = await Process.run(
+        tailwindPath,
+        ["-i", input, "-o", output],
+      );
+      if (result.exitCode != 0) {
+        context.log.warn("Failed to run Tailwind CSS compilation - exist code: ${result.exitCode}");
+        return;
+      }
+
+      context.log.detail("Successfully generated Tailwind CSS: $output");
+    } catch (exception, stacktrace) {
+      context.log.warn("Failed to run Tailwind CSS compilation!");
+      context.log.err("$exception");
+      context.log.err("$stacktrace");
+    }
+  }
+}

--- a/packages/static_shock/lib/src/plugins/tailwind_css.dart
+++ b/packages/static_shock/lib/src/plugins/tailwind_css.dart
@@ -7,13 +7,13 @@ import 'package:static_shock/src/static_shock.dart';
 /// [StaticShockPlugin] that runs Tailwind CSS against the project's source files.
 ///
 /// This plugin depends on the presence of the Tailwind binary tool. By default,
-/// that tool is expected to be named `tailwind` and to sit at the root of the
+/// that tool is expected to be named `tailwindcss` and to sit at the root of the
 /// website project directory.
 ///
 /// Learn more about the standalone Tailwind tool: https://tailwindcss.com/blog/standalone-cli
 class TailwindPlugin implements StaticShockPlugin {
   const TailwindPlugin({
-    this.tailwindPath = "./tailwind",
+    this.tailwindPath = "./tailwindcss",
     required this.input,
     required this.output,
   });
@@ -78,6 +78,7 @@ class _TailwindGenerator implements Finisher {
   Future<void> execute(StaticShockPipelineContext context) async {
     try {
       context.log.info("Generating Tailwind CSS");
+      context.log.detail("Tailwind executable path: $tailwindPath");
       context.log.detail("Tailwind input file: $input");
       final result = await Process.run(
         tailwindPath,

--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -647,6 +647,8 @@ class StaticShock implements StaticShockPipeline {
 /// These plugins include markdown page generation, jinja pages and templates, and
 /// pretty URLs.
 abstract class StaticShockPlugin {
+  const StaticShockPlugin();
+
   /// Configures the [pipeline] to add new features that are associated with
   /// this plugin.
   FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {}

--- a/packages/static_shock/lib/static_shock.dart
+++ b/packages/static_shock/lib/static_shock.dart
@@ -23,3 +23,4 @@ export 'src/plugins/pub_package.dart';
 export 'src/plugins/redirects.dart';
 export 'src/plugins/rss.dart';
 export 'src/plugins/sass.dart';
+export 'src/plugins/tailwind_css.dart';

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -10,6 +10,8 @@ docs_menu:
     id: copy-assets
   - title: Compile Sass
     id: compile-sass
+  - title: Compile TailwindCSS
+    id: compile-tailwind
   - title: Draft Articles
     id: draft-articles
   - title: Use Remote CSS and JS

--- a/packages/static_shock_docs/source/guides/compile-tailwind.md
+++ b/packages/static_shock_docs/source/guides/compile-tailwind.md
@@ -1,0 +1,117 @@
+---
+title: Compile Tailwind
+tags: styling
+---
+Static Shock includes a plugin that you can use to compile Tailwind classes in your website.
+
+Tailwind is a CSS compilation tool that focuses on writing styles within your HTML tags, instead
+of separating your styles into CSS classes. Learn more about Tailwind in the 
+[official docs](https://tailwindcss.com/docs/installation).
+
+## Activate the Tailwind plugin
+Tell Static Shock to run the Tailwind compilation process by adding the Tailwind plugin.
+
+```dart
+Future<void> main(List<String> arguments) async {
+  // Configure the static website generator.
+  final staticShock = StaticShock()
+    // ...existing configuration here...
+    ..plugin(const TailwindPlugin(
+      input: "source/styles/tailwind.css",
+      output: "build/styles/tailwind.css",
+    ));
+
+  // Generate the static website.
+  await staticShock.generateSite();
+}
+```
+
+You'll need to provide the path to your Tailwind source file, and a desired destination for
+your compiled Tailwind output file. Those files, and other Tailwind setup steps, are discussed
+below.
+
+## Add Tailwind to your project
+Tailwind is typically added to projects through NPM or some other JavaScript package manager.
+Static Shock is written in Dart and relies on the Pub package ecosystem. Therefore, Static Shock
+projects can't use the standard pathway to integrate Tailwind. However, there's still an easy
+path to integrate Tailwind.
+
+Tailwind distributes a binary tool for exactly situations like ours.
+
+### Download the standalone CLI tool
+[Download the Tailwind standalone CLI tool](https://tailwindcss.com/blog/standalone-cli) directly 
+into your project. Place it at the top-level of your Static Shock project and call it `tailwind`.
+
+For example, on a Mac computer, you might run the following:
+
+```
+curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-arm64
+chmod +x tailwindcss-macos-arm64
+mv tailwindcss-macos-arm64 tailwindcss
+```
+
+### Create a Tailwind configuration file
+Tailwind inspects files looking for Tailwind CSS classes to compile. Therefore, you need to tell
+Tailwind which files to look at.
+
+First, create the Tailwind configuration file in the same directory where you placed the
+`tailwind` tool. Call it `tailwind.config.js`.
+
+Second, in the configuration file, tell Tailwind which files to inspect.
+
+In this example we tell Tailwind to only look at our source files, and we further tell Tailwind
+to only look at our Jinja template files, which is where we write our HTML.
+
+```javascript
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './source/**/*.jinja',
+  ],
+}
+```
+
+### Create your base Tailwind CSS configuration
+Create a CSS file to hold your baseline Tailwind CSS preferences.
+
+A common place for this file is `/source/styles/tailwind.css`.
+
+If you're familiar with Tailwind, you probably know what to place in this file. For those
+new to Tailwind, place the following code in `tailwind.css`.
+
+```
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+Your site is now ready to compile Tailwind classes. The final step is to actually use the
+CSS that Tailwind generates.
+
+### Include Tailwind CSS in your HTML
+The final output from Tailwind is a single CSS file. That file will appear wherever you tell
+the `TailwindPlugin` to put it. A common location is `/build/styles/tailwind.css`.
+
+You need to import this CSS file in all HTML/Jinja files where you made use of Tailwind CSS
+classes.
+
+```html
+<html>
+  <head>
+    <link href="/styles/tailwind.css" rel="stylesheet">
+  </head>
+  <body></body>
+</html>
+```
+
+With the final output file added to your HTML, every time you build your static site, your
+webpages will magically apply Tailwind CSS classes.
+
+## How does Tailwind integrate with Static Shock?
+When you apply the `TailwindPlugin` to your Static Shock website, Static Shock runs the Tailwind
+tool whenever you build your site. During the standard Static Shock build phase, Static Shock
+starts a separate process and runs the standard Tailwind compilation step.
+
+The output from the Tailwind process is a single CSS file that includes all the CSS needed
+by the Tailwind classes that you added to your HTML. That CSS file is then imported by your
+HTML files when you view your HTML files in the browser.


### PR DESCRIPTION
Added plugin for Tailwind CSS (Resolves #145)

This plugin simply creates a place in the generation process to call out to the Tailwind CSS binary tool: https://tailwindcss.com/blog/standalone-cli

It's up to the user to include an appropriate Tailwind binary in their project.