### PR TITLE
Fix: Prettify URLs for pages with explicit index files (Resolves #152)

### DIFF
--- a/packages/static_shock/lib/src/files.dart
+++ b/packages/static_shock/lib/src/files.dart
@@ -151,7 +151,8 @@ class FileRelativePath implements RelativePath {
   DirectoryRelativePath get containingDirectory => DirectoryRelativePath(directoryPath);
 
   @override
-  List<String> get directories => directoryPath.split(Platform.pathSeparator).where((item) => item.isNotEmpty).toList();
+  List<String> get directories => directoryPath.split(Platform.pathSeparator).where((item) => item.isNotEmpty).toList()
+    ..removeWhere((dirName) => dirName == "." || dirName == "..");
 
   FileRelativePath copyWith({
     String? directoryPath,

--- a/packages/static_shock/test/plugins/pretty_urls_test.dart
+++ b/packages/static_shock/test/plugins/pretty_urls_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:static_shock/static_shock.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group("Plugins > pretty URLs >", () {
+    test("pretties URL for page with single source file", () async {
+      final context = StaticShockPipelineContext(Logger(), Directory("/User/Fake/website"));
+      final page = Page(FileRelativePath("./posts/news", "fake", "md"), "");
+      context.pagesIndex.addPage(page);
+
+      PrettyPathPageTransformer().transformPage(context, page);
+
+      expect(page.url, "/posts/news/fake/");
+    });
+
+    test("pretties URL for page with explicit index file", () async {
+      final context = StaticShockPipelineContext(Logger(), Directory("/User/Fake/website"));
+      final page = Page(FileRelativePath("./posts/news/fake", "index", "md"), "");
+      context.pagesIndex.addPage(page);
+
+      PrettyPathPageTransformer().transformPage(context, page);
+
+      expect(page.url, "/posts/news/fake/");
+    });
+
+    test("pretties URL for root-level page", () async {
+      final context = StaticShockPipelineContext(Logger(), Directory("/User/Fake/website"));
+      final page = Page(FileRelativePath("./", "fake", "md"), "");
+      context.pagesIndex.addPage(page);
+
+      PrettyPathPageTransformer().transformPage(context, page);
+
+      expect(page.url, "/fake/");
+    });
+
+    test("keeps root level index HTML file as-is", () async {
+      final context = StaticShockPipelineContext(Logger(), Directory("/User/Fake/website"));
+      final page = Page(FileRelativePath("./", "index", "html"), "");
+      context.pagesIndex.addPage(page);
+
+      PrettyPathPageTransformer().transformPage(context, page);
+
+      expect(page.url, "/");
+    });
+
+    test("keeps root level index Markdown file as-is", () async {
+      final context = StaticShockPipelineContext(Logger(), Directory("/User/Fake/website"));
+      final page = Page(FileRelativePath("./", "index", "md"), "");
+      context.pagesIndex.addPage(page);
+
+      PrettyPathPageTransformer().transformPage(context, page);
+
+      expect(page.url, "/");
+    });
+  });
+}


### PR DESCRIPTION
Fix: Prettify URLs for pages with explicit index files (Resolves #152)

Consider a file like `source/posts/news/some-event/index.md`. It should map to URL `/posts/news/some-event/` but instead was mapping to `/posts/news/some-event/index.html`. 