### PR TITLE
[Docs] - Fix: Guide menu not showing.

### DIFF
--- a/packages/static_shock/lib/src/plugins/menus.dart
+++ b/packages/static_shock/lib/src/plugins/menus.dart
@@ -71,7 +71,7 @@ List _pageExistsForMenuItem(
   final filteredMenuItems = <Object>[];
   for (final menuItem in menuItems) {
     final pathFragments = [...prefixPathFragments, menuItem['id']];
-    final url = "${pathFragments.join("/")}/";
+    final url = "${pathFragments.isNotEmpty ? "/" : ""}${pathFragments.join("/")}/";
     for (final page in context.pagesIndex.pages) {
       if (page.url == url) {
         filteredMenuItems.add(menuItem);


### PR DESCRIPTION
[Docs] - Fix: Guide menu not showing.

A recent change to the `url` property of `Page`s requires a leading `/`, which was missing from the Jinja template function that filters out non-existent pages. I.e., the filter thought none of the pages existed, when they do.