### PR TITLE
[Shock] - Added Jinja filter called 'pathRelativeToPage' to build URLs on top of page URL (Relates to #164)

### DIFF
--- a/packages/static_shock/lib/src/plugins/jinja.dart
+++ b/packages/static_shock/lib/src/plugins/jinja.dart
@@ -162,6 +162,7 @@ class JinjaPageRenderer implements PageRenderer {
       MapEntry("startsWith", _startsWith),
       MapEntry("formatDateTime", _formatDateTime),
       MapEntry("take", _take),
+      MapEntry("pathRelativeToPage", (String relativePath) => _pathRelativeToPage(page, relativePath)),
       ...filters.map((filterBuilder) {
         final filter = filterBuilder(context);
         return MapEntry<String, Function>(filter.$1, filter.$2);
@@ -273,4 +274,16 @@ class JinjaPageRenderer implements PageRenderer {
 
   /// A Jinja filter that returns the first [count] items from the given list.
   List _take(List incoming, int count) => incoming.sublist(0, min(count, incoming.length));
+
+  /// A Jinja filter (with a [Page] for context), which treats [relativePath] as a path
+  /// that's relative the [page], and returns the full URL path that combines the two.
+  ///
+  /// Example:
+  ///  - Page URL: `/posts/my-article/index.html`
+  ///  - relativePath: `images/my-photo.png`
+  ///  - return value: `/posts/my-article/images/my-photo.png`
+  String _pathRelativeToPage(Page page, String relativePath) {
+    final pageUrl = Uri.parse(page.url!);
+    return pageUrl.resolve(relativePath).path;
+  }
 }


### PR DESCRIPTION
[Shock] - Added Jinja filter called 'pathRelativeToPage' to build URLs on top of page URL (Relates to #164)

This PR doesn't actually resolve #164. When I worked on the problem, I found that the `Page` `url` property was giving us just the path, e.g., `/posts/my-post/`. We don't have any official access to the root domain, so there's no way to solve #164 without first deciding where the domain name should officially live. I didn't want to tackle that right at this moment.

With this approach, assuming a website defines it's own data property called `homepage_url`, a URL can be built as follows:

```jinja
{{ homepage_url }}{{ "images/photo.png" | pathRelativeToPage }}
```

We should still make this much easier in the future, but this is enough to unblock some other work.