### PR TITLE
Add staticshock.io showcase, WebsiteScreenshotsPlugin, and a Static Shock build cache (Resolves #161)(Resolves #117)

### DIFF
--- a/melos_static_shock.iml
+++ b/melos_static_shock.iml
@@ -22,6 +22,15 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/template_sources/template_docs/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages/template_sources/template_docs/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/packages/template_sources/template_docs/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_blog/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_blog/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_blog/build" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_docs_multi_page/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_docs_multi_page/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_docs_multi_page/build" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_empty/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_empty/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/template_sources/template_empty/build" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/packages/static_shock/lib/src/assets.dart
+++ b/packages/static_shock/lib/src/assets.dart
@@ -4,6 +4,10 @@ import 'dart:typed_data';
 import 'files.dart';
 import 'pipeline.dart';
 
+abstract class AssetLoader {
+  FutureOr<Asset> loadAssets();
+}
+
 abstract class AssetTransformer {
   FutureOr<void> transformAsset(StaticShockPipelineContext context, Asset asset);
 }

--- a/packages/static_shock/lib/src/assets.dart
+++ b/packages/static_shock/lib/src/assets.dart
@@ -4,8 +4,12 @@ import 'dart:typed_data';
 import 'files.dart';
 import 'pipeline.dart';
 
+/// Loads some number of assets, possibly by loading them from remote sources,
+/// or by generating them locally.
+///
+/// Asset loading runs before asset transformation.
 abstract class AssetLoader {
-  FutureOr<Asset> loadAssets();
+  FutureOr<void> loadAssets(StaticShockPipelineContext context);
 }
 
 abstract class AssetTransformer {

--- a/packages/static_shock/lib/src/cache.dart
+++ b/packages/static_shock/lib/src/cache.dart
@@ -1,0 +1,217 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:yaml/yaml.dart' as yaml;
+
+/// File-system cache, which retains data between builds so that expensive
+/// tasks aren't repeated, unnecessarily.
+///
+/// During development, a rebuild runs after every source code change. This means
+/// a rebuild every few seconds. At that build rate, it becomes impractical to
+/// repeatedly run expensive tasks, such as the following:
+///
+///  * Load data from web services.
+///  * Take screenshots of webpages.
+///  * Generate artwork.
+///
+/// Each [StaticShockCache] points to a different directory to avoid cached file
+/// collisions. For example, Static Shock might provide different [StaticShockCache]s
+/// to each plugin, and yet another cache to the application, itself. As a result,
+/// each plugin is prevented from accessing cached files from other plugins, and the
+/// application is unable to access any plugin cached filed.
+class StaticShockCache {
+  const StaticShockCache(this._directory);
+
+  final Directory _directory;
+
+  /// Returns `true` if this cache contains content for the given [id].
+  ///
+  /// Clients are expected to know the type of the cached data, which
+  /// can be accessed with [loadPlainText], [loadJsonObject], [loadJsonList],
+  /// [loadYaml], or [loadBinary].
+  Future<bool> contains(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    final cacheFile = _getFileForId(id);
+    return await cacheFile.exists();
+  }
+
+  /// Stores the given [text] in this cache, mapped to the given [id].
+  Future<void> putPlainText(String id, String text) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    await _writeTextToFile(id, text);
+  }
+
+  /// Loads the data for the given [id] and interprets that data plain text.
+  Future<String?> loadPlainText(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    return await _loadTextFromFile(id);
+  }
+
+  /// Stores the given [json] object in this cache, mapped to the given [id].
+  Future<void> putJsonObject(String id, Map<String, dynamic> json) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    final jsonText = JsonEncoder().convert(json);
+    await _writeTextToFile(id, jsonText);
+  }
+
+  /// Loads the data for the given [id] and interprets that data as a JSON object.
+  Future<Map<String, dynamic>?> loadJsonObject(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    final jsonText = await _loadTextFromFile(id);
+    if (jsonText == null || jsonText.isEmpty) {
+      return null;
+    }
+
+    return JsonDecoder().convert(jsonText) as Map<String, dynamic>?;
+  }
+
+  /// Stores the given [json] list in this cache, mapped to the given [id].
+  Future<void> putJsonList(String id, List<dynamic> json) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    final jsonText = JsonEncoder().convert(json);
+    await _writeTextToFile(id, jsonText);
+  }
+
+  /// Loads the data for the given [id] and interprets that data as a JSON list.
+  Future<List<dynamic>?> loadJsonList(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    final jsonText = await _loadTextFromFile(id);
+    if (jsonText == null || jsonText.isEmpty) {
+      return null;
+    }
+
+    return JsonDecoder().convert(jsonText) as List<dynamic>?;
+  }
+
+  /// Stores the given [yaml] in this cache, mapped to the given [id].
+  Future<void> putYaml(String id, yaml.YamlDocument yaml) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    await _writeTextToFile(id, yaml.toString());
+  }
+
+  /// Loads the data for the given [id] and interprets that data as YAML.
+  ///
+  /// The return type is `dynamic` because the `yaml` package also declares
+  /// a return type of `dynamic` from `loadYaml`. The return type is expected
+  /// to be either a [yaml.YamlNode], or a [yaml.YamlScalar], or `null` if
+  /// no YAML data exists.
+  Future<dynamic> loadYaml(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    final yamlText = await _loadTextFromFile(id);
+    if (yamlText == null) {
+      return null;
+    }
+
+    return yaml.loadYaml(yamlText);
+  }
+
+  /// Stores the given [binary] in this cache, mapped to the given [id].
+  Future<void> putBinary(String id, Uint8List binary) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    await _writeBinaryToFile(id, binary);
+  }
+
+  /// Loads the binary data for the given [id] and interprets that data as binary.
+  Future<Uint8List?> loadBinary(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+
+    return await _loadBinaryFromFile(id);
+  }
+
+  /// Deletes the file in this cache with the given [id].
+  Future<void> delete(String id) async {
+    _ensureInitialized();
+    _ensureValidId(id);
+    //
+  }
+
+  /// Deletes all files in this cache.
+  Future<void> deleteAll() async {
+    _ensureInitialized();
+    //
+  }
+
+  void _ensureInitialized() {
+    if (_directory.existsSync()) {
+      return;
+    }
+
+    try {
+      _directory.createSync(recursive: true);
+    } catch (exception) {
+      throw Exception("Failed to create a new cache directory at: ${_directory.absolute.path}");
+    }
+  }
+
+  void _ensureValidId(String id) {
+    if (id.isEmpty) {
+      throw Exception("Invalid StaticShockCache ID - IDs can't be empty.");
+    }
+  }
+
+  File _getFileForId(String id) {
+    return File("${_directory.path}${Platform.pathSeparator}$id");
+  }
+
+  Future<String?> _loadTextFromFile(String id) async {
+    final cacheFile = _getFileForId(id);
+    final exists = await cacheFile.exists();
+    if (!exists) {
+      return null;
+    }
+
+    return await cacheFile.readAsString();
+  }
+
+  Future<void> _writeTextToFile(String id, String content) async {
+    final cacheFile = _getFileForId(id);
+    final exists = await cacheFile.exists();
+    if (!exists) {
+      await cacheFile.create();
+    }
+
+    await cacheFile.writeAsString(content);
+  }
+
+  Future<Uint8List?> _loadBinaryFromFile(String id) async {
+    final cacheFile = _getFileForId(id);
+    final exists = await cacheFile.exists();
+    if (!exists) {
+      return null;
+    }
+
+    return await cacheFile.readAsBytes();
+  }
+
+  Future<void> _writeBinaryToFile(String id, Uint8List content) async {
+    final cacheFile = _getFileForId(id);
+    final exists = await cacheFile.exists();
+    if (!exists) {
+      await cacheFile.create();
+    }
+
+    await cacheFile.writeAsBytes(content);
+  }
+}

--- a/packages/static_shock/lib/src/pipeline.dart
+++ b/packages/static_shock/lib/src/pipeline.dart
@@ -45,7 +45,7 @@ abstract class StaticShockPipeline {
   /// Adds the given [AssetLoader] to the pipeline, which loads and adds assets that
   /// weren't [pick]'ed, e.g., loading an image from network, or generating an image
   /// during the build process.
-  // void loadAssets(AssetLoader loader);
+  void loadAssets(AssetLoader loader);
 
   /// Adds the given [AssetTransformer] to the pipeline, which copies, alters, and
   /// saves assets from the source set to the build set.

--- a/packages/static_shock/lib/src/pipeline.dart
+++ b/packages/static_shock/lib/src/pipeline.dart
@@ -42,6 +42,11 @@ abstract class StaticShockPipeline {
   /// any assets or pages are loaded.
   void loadData(DataLoader dataLoader);
 
+  /// Adds the given [AssetLoader] to the pipeline, which loads and adds assets that
+  /// weren't [pick]'ed, e.g., loading an image from network, or generating an image
+  /// during the build process.
+  // void loadAssets(AssetLoader loader);
+
   /// Adds the given [AssetTransformer] to the pipeline, which copies, alters, and
   /// saves assets from the source set to the build set.
   void transformAssets(AssetTransformer transformer);

--- a/packages/static_shock/lib/src/plugins/drafting.dart
+++ b/packages/static_shock/lib/src/plugins/drafting.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:static_shock/src/cache.dart';
 import 'package:static_shock/src/pages.dart';
 import 'package:static_shock/src/pipeline.dart';
 import 'package:static_shock/src/static_shock.dart';
@@ -25,10 +26,17 @@ class DraftingPlugin implements StaticShockPlugin {
     this.showDrafts = false,
   });
 
+  @override
+  final id = "io.staticshock.drafting";
+
   final bool showDrafts;
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.filterPages(
       _DraftPageFilter(showDrafts: showDrafts),
     );

--- a/packages/static_shock/lib/src/plugins/jinja.dart
+++ b/packages/static_shock/lib/src/plugins/jinja.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:intl/intl.dart';
 import 'package:jinja/jinja.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:static_shock/src/cache.dart';
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/pages.dart';
 import 'package:static_shock/src/pipeline.dart';
@@ -17,11 +18,18 @@ class JinjaPlugin implements StaticShockPlugin {
     this.tests = const [],
   });
 
+  @override
+  final id = "io.staticshock.jinja";
+
   final List<StaticShockJinjaFunctionBuilder> filters;
   final List<StaticShockJinjaFunctionBuilder> tests;
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.pick(const ExtensionPicker("jinja"));
     pipeline.loadPages(JinjaPageLoader(context.log));
     pipeline.renderPages(JinjaPageRenderer(

--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:fbh_front_matter/fbh_front_matter.dart' as front_matter;
 import 'package:markdown/markdown.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:static_shock/src/cache.dart';
 
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/pages.dart';
@@ -15,10 +16,17 @@ class MarkdownPlugin implements StaticShockPlugin {
     this.renderOptions = const MarkdownRenderOptions(),
   });
 
+  @override
+  final id = "io.staticshock.markdown";
+
   final MarkdownRenderOptions renderOptions;
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline
       ..pick(const ExtensionPicker("md"))
       ..loadPages(MarkdownPageLoader(context.log))

--- a/packages/static_shock/lib/src/plugins/pretty_urls.dart
+++ b/packages/static_shock/lib/src/plugins/pretty_urls.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:static_shock/src/cache.dart';
 import 'package:static_shock/src/pipeline.dart';
 import 'package:static_shock/src/static_shock.dart';
 
@@ -9,8 +10,14 @@ import '../pages.dart';
 class PrettyUrlsPlugin implements StaticShockPlugin {
   const PrettyUrlsPlugin();
 
+  final id = "io.staticshock.prettyurls";
+
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.transformPages(const PrettyPathPageTransformer());
   }
 }

--- a/packages/static_shock/lib/src/plugins/pub_package.dart
+++ b/packages/static_shock/lib/src/plugins/pub_package.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:pub_updater/pub_updater.dart';
+import 'package:static_shock/src/cache.dart';
 import 'package:static_shock/src/data.dart';
 import 'package:static_shock/src/pipeline.dart';
 import 'package:static_shock/src/static_shock.dart';
@@ -27,10 +28,17 @@ import 'package:yaml/yaml.dart';
 class PubPackagePlugin implements StaticShockPlugin {
   const PubPackagePlugin([this._packageNames = const <String>{}]);
 
+  @override
+  final id = "io.staticshock.pubpackage";
+
   final Set<String> _packageNames;
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.loadData(
       _PubPackageDataLoader(_packageNames),
     );

--- a/packages/static_shock/lib/src/plugins/redirects.dart
+++ b/packages/static_shock/lib/src/plugins/redirects.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:path/path.dart' as path;
+import 'package:static_shock/src/cache.dart';
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/finishers.dart';
 import 'package:static_shock/src/pipeline.dart';
@@ -28,7 +29,14 @@ class RedirectsPlugin implements StaticShockPlugin {
   const RedirectsPlugin();
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  final id = "io.staticshock.redirects";
+
+  @override
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.finish(
       RedirectsFinisher(),
     );

--- a/packages/static_shock/lib/src/plugins/rss.dart
+++ b/packages/static_shock/lib/src/plugins/rss.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dart_rss/dart_rss.dart';
 import 'package:intl/intl.dart';
 import 'package:static_shock/src/assets.dart';
+import 'package:static_shock/src/cache.dart';
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/finishers.dart';
 import 'package:static_shock/src/pages.dart';
@@ -32,6 +33,9 @@ class RssPlugin implements StaticShockPlugin {
     this.pageToRssItemMapper = defaultPageToRssItemMapper,
   });
 
+  @override
+  final id = "io.staticshock.rss";
+
   /// Top-level website information for the `<channel>` configuration.
   final RssSiteConfiguration site;
 
@@ -50,7 +54,11 @@ class RssPlugin implements StaticShockPlugin {
   final PageToRssItemMapper pageToRssItemMapper;
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.finish(_RssFinisher(
       site: site,
       rssFeedPath: rssFeedPath,

--- a/packages/static_shock/lib/src/plugins/sass.dart
+++ b/packages/static_shock/lib/src/plugins/sass.dart
@@ -15,7 +15,14 @@ class SassPlugin implements StaticShockPlugin {
   const SassPlugin();
 
   @override
-  FutureOr<void> configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  final id = "io.staticshock.sass";
+
+  @override
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     // We assemble our own Sass importer that we call SassEnvironment where we
     // collect all the available Sass files so they can reference each other.
     //

--- a/packages/static_shock/lib/src/plugins/tailwind_css.dart
+++ b/packages/static_shock/lib/src/plugins/tailwind_css.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:static_shock/src/finishers.dart';
 import 'package:static_shock/src/pipeline.dart';
 import 'package:static_shock/src/static_shock.dart';
+import 'package:static_shock/static_shock.dart';
 
 /// [StaticShockPlugin] that runs Tailwind CSS against the project's source files.
 ///
@@ -17,6 +18,9 @@ class TailwindPlugin implements StaticShockPlugin {
     required this.input,
     required this.output,
   });
+
+  @override
+  final id = "io.staticshock.tailwind";
 
   /// Path and name of the Tailwind executable.
   final String tailwindPath;
@@ -49,7 +53,11 @@ class TailwindPlugin implements StaticShockPlugin {
   final String output;
 
   @override
-  void configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+  void configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
     pipeline.finish(_TailwindGenerator(
       tailwindPath: tailwindPath,
       input: input,

--- a/packages/static_shock/lib/src/plugins/website_screenshots.dart
+++ b/packages/static_shock/lib/src/plugins/website_screenshots.dart
@@ -1,62 +1,208 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:image/image.dart';
 import 'package:puppeteer/puppeteer.dart';
-import 'package:static_shock/src/assets.dart';
-import 'package:static_shock/src/data.dart';
-import 'package:static_shock/src/files.dart';
-import 'package:static_shock/src/pipeline.dart';
-import 'package:static_shock/src/static_shock.dart';
+import 'package:static_shock/static_shock.dart';
 
+/// A [StaticShockPlugin] that takes screenshots of webpages and places those
+/// screenshots in the final website build at desired locations.
 class WebsiteScreenshotsPlugin extends StaticShockPlugin {
-  const WebsiteScreenshotsPlugin(this.screenshots);
-
-  final Set<WebsiteScreenshot> screenshots;
+  const WebsiteScreenshotsPlugin({
+    this.screenshots = const <WebsiteScreenshot>{},
+    this.selector,
+    this.viewportSize = const ViewportSize(width: 1280, height: 720),
+    this.outputWidth,
+    this.outputHeight,
+    this.useCache = true,
+    this.forceCacheRefresh = false,
+  }) : assert(!forceCacheRefresh || useCache, "To use forceCacheRefresh, useCache must be `true`.");
 
   @override
-  void configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
-    pipeline.loadData(
-      WebsiteScreenshotsDataLoader(screenshots),
+  final id = "io.staticshock.websitescreenshots";
+
+  /// The webpages that should be screenshotted, and their final image
+  /// locations.
+  final Set<WebsiteScreenshot> screenshots;
+
+  /// A user-provided delegate that finds desired [WebsiteScreenshot]s by reading
+  /// the global data index.
+  ///
+  /// This can be used, for example, to define desired screenshots in a local
+  /// YAML file and then read that YAML data to request [WebsiteScreenshot]s.
+  final WebsiteScreenshotSelector? selector;
+
+  /// The dimensions of the browser, which determines the dimensions of the screenshot.
+  final ViewportSize viewportSize;
+
+  /// The final width of the screenshot image, or `null` to keep the screenshot
+  /// at its original width.
+  final int? outputWidth;
+
+  /// The final height of the screenshot image, or `null` to keep the screenshot
+  /// at its original height.
+  final int? outputHeight;
+
+  /// `true` to place screenshots in a cache directory so that they can be re-used
+  /// across builds, or `false` to take fresh screenshots on every build.
+  final bool useCache;
+
+  /// `true` to take fresh screenshots and overwrite any existing screenshots in the
+  /// cache.
+  final bool forceCacheRefresh;
+
+  @override
+  void configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
+    pipeline.loadAssets(
+      WebsiteScreenshotsAssetLoader(
+        pluginCache,
+        screenshots: screenshots,
+        selector: selector,
+        viewportSize: viewportSize,
+        outputWidth: outputWidth,
+        outputHeight: outputHeight,
+        useCache: useCache,
+        forceCacheRefresh: forceCacheRefresh,
+      ),
     );
   }
 }
 
-class WebsiteScreenshotsDataLoader implements DataLoader {
-  const WebsiteScreenshotsDataLoader(this.screenshots);
+typedef WebsiteScreenshotSelector = Set<WebsiteScreenshot> Function(StaticShockPipelineContext context);
+
+class WebsiteScreenshotsAssetLoader implements AssetLoader {
+  const WebsiteScreenshotsAssetLoader(
+    this.cache, {
+    this.screenshots = const <WebsiteScreenshot>{},
+    this.selector,
+    this.viewportSize = const ViewportSize(width: 1280, height: 720),
+    this.outputWidth,
+    this.outputHeight,
+    this.useCache = true,
+    this.forceCacheRefresh = false,
+  });
 
   final Set<WebsiteScreenshot> screenshots;
 
-  @override
-  Future<Map<String, Object>> loadData(StaticShockPipelineContext context) async {
-    final stopwatch = Stopwatch()..start();
+  /// A user-provided delegate that finds desired [WebsiteScreenshot]s by reading
+  /// the global data index.
+  ///
+  /// This can be used, for example, to define desired screenshots in a local
+  /// YAML file and then read that YAML data to request [WebsiteScreenshot]s.
+  final WebsiteScreenshotSelector? selector;
 
+  final StaticShockCache cache;
+
+  /// The dimensions of the browser, which determines the dimensions of the screenshot.
+  final ViewportSize viewportSize;
+
+  /// The final width of the screenshot image, or `null` to keep the screenshot
+  /// at its original width.
+  final int? outputWidth;
+
+  /// The final height of the screenshot image, or `null` to keep the screenshot
+  /// at its original height.
+  final int? outputHeight;
+
+  /// `true` to place screenshots in a cache directory so that they can be re-used
+  /// across builds, or `false` to take fresh screenshots on every build.
+  final bool useCache;
+
+  /// `true` to take fresh screenshots and overwrite any existing screenshots in the
+  /// cache.
+  final bool forceCacheRefresh;
+
+  @override
+  Future<void> loadAssets(StaticShockPipelineContext context) async {
+    final screenshots = Set.from(this.screenshots);
+    if (selector != null) {
+      screenshots.addAll(selector!(context));
+    }
+
+    if (screenshots.isEmpty) {
+      return;
+    }
+
+    context.log.detail("Taking screenshots of webpages...");
+    final stopwatch = Stopwatch()..start();
+    final screenshotsToTake = List<WebsiteScreenshot>.from(screenshots);
+
+    // Find all cached screenshots and load them as assets.
+    if (useCache && !forceCacheRefresh) {
+      await _loadCachedScreenshots(context, screenshotsToTake);
+    }
+    if (screenshotsToTake.isEmpty) {
+      // All screenshots were cached. No need to start a browser to take screenshots.
+      return;
+    }
+
+    // Take fresh screenshots for items not in the cache.
+    await _takeScreenshots(context, screenshotsToTake);
+
+    stopwatch.stop();
+    context.log.detail(
+        "Done screenshotting webpages - Total screenshot time: ${stopwatch.elapsedMilliseconds.toDouble() / 1000}s");
+
+    return;
+  }
+
+  Future<void> _loadCachedScreenshots(
+    StaticShockPipelineContext context,
+    List<WebsiteScreenshot> screenshotsToTake,
+  ) async {
+    context.log.detail("Checking for cached screenshots...");
+    final screenshots = Set.from(screenshotsToTake);
+    for (final screenshot in screenshots) {
+      final screenshotCacheName = "${screenshot.id}.png";
+      if (await cache.contains(screenshotCacheName)) {
+        context.log.detail("Loading cached screenshot for: $screenshotCacheName");
+        final cachedScreenshot = await cache.loadBinary(screenshotCacheName);
+        if (cachedScreenshot == null) {
+          // For some reason the cached file was empty. Ignore this cache value.
+          context.log.detail("Screenshot ${screenshot.id}.png isn't in the cache");
+          continue;
+        }
+        context.log.detail("Loading ${screenshot.id}.png from the cache");
+
+        // Add the cached image to the assets collection.
+        context.addAsset(
+          Asset(
+            destinationPath: screenshot.output,
+            destinationContent: AssetContent.binary(cachedScreenshot),
+          ),
+        );
+
+        // Remove this screenshot from the list of new screenshots that
+        // need to be taken.
+        screenshotsToTake.remove(screenshot);
+      }
+    }
+    context.log.detail("Done loading cached screenshots.");
+  }
+
+  Future<void> _takeScreenshots(StaticShockPipelineContext context, List<WebsiteScreenshot> screenshotsToTake) async {
     final screenshotFutures = <Future>[];
 
-    print("Launching browser...");
-    final viewportSize = ViewportSize(width: 1280, height: 1024);
+    context.log.detail("Launching headless browser...");
     final browser = await puppeteer.launch(
       headless: true,
       defaultViewport: DeviceViewport(width: viewportSize.width, height: viewportSize.height),
     );
-    print("Browser is launched.");
-    for (final screenshot in screenshots) {
-      print("Taking screenshot of: ${screenshot.url}");
-      screenshotFutures.add(_takeScreenshot(context, browser, viewportSize, screenshot));
+    context.log.detail("Browser is launched.");
+    for (final screenshot in screenshotsToTake) {
+      context.log.detail("Taking screenshot of: ${screenshot.url}");
+      screenshotFutures.add(_takeScreenshot(context, browser, screenshot));
     }
     await Future.wait(screenshotFutures);
     browser.close();
-
-    stopwatch.stop();
-    print("Total screenshot time: ${stopwatch.elapsedMilliseconds.toDouble() / 1000}s");
-
-    return {};
   }
 
   Future<void> _takeScreenshot(
     StaticShockPipelineContext context,
     Browser browser,
-    ViewportSize viewport,
     WebsiteScreenshot screenshot,
   ) async {
     final page = await browser.newPage();
@@ -64,26 +210,37 @@ class WebsiteScreenshotsDataLoader implements DataLoader {
     final bitmap = await page.screenshot(
       format: ScreenshotFormat.png,
       fullPage: false,
-      clip: Rectangle(0, 0, viewport.width, viewport.height),
+      clip: Rectangle(0, 0, viewportSize.width, viewportSize.height),
     );
     page.close();
 
-    final image = decodePng(bitmap)!;
-    final smallImage = copyResize(image, width: 256, interpolation: Interpolation.average);
+    var image = decodePng(bitmap)!;
+    if (outputWidth != null || outputHeight != null) {
+      // Resize the screenshot as desired.
+      image = copyResize(
+        image,
+        width: outputWidth,
+        height: outputHeight,
+        interpolation: Interpolation.average,
+      );
+    }
+    final pngBinary = encodePng(image);
 
     context.addAsset(
       Asset(
         destinationPath: screenshot.output,
-        destinationContent: AssetContent.binary(
-          encodePng(smallImage),
-        ),
+        destinationContent: AssetContent.binary(pngBinary),
       ),
     );
+
+    if (useCache) {
+      cache.putBinary("${screenshot.id}.png", pngBinary);
+    }
   }
 }
 
 class ViewportSize {
-  ViewportSize({
+  const ViewportSize({
     required this.width,
     required this.height,
   });
@@ -108,9 +265,30 @@ class ViewportSize {
 }
 
 class WebsiteScreenshot {
-  const WebsiteScreenshot(this.id, this.url, this.output);
+  const WebsiteScreenshot({
+    required this.id,
+    required this.url,
+    required this.output,
+  });
 
+  /// ID that uniquely identifies this screenshot from all other
+  /// screenshots.
+  ///
+  /// The [id] is used to cache the screenshot between builds. Therefore,
+  /// two or more screenshots with the sam [id] will overwrite each other.
   final String id;
+
+  /// The URL of the webpage to screenshot.
   final Uri url;
+
+  /// The file path and name within the final build directory where this screenshot
+  /// image should be placed.
   final FileRelativePath output;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is WebsiteScreenshot && runtimeType == other.runtimeType && id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
 }

--- a/packages/static_shock/lib/src/plugins/website_screenshots.dart
+++ b/packages/static_shock/lib/src/plugins/website_screenshots.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:image/image.dart';
+import 'package:puppeteer/puppeteer.dart';
+import 'package:static_shock/src/assets.dart';
+import 'package:static_shock/src/data.dart';
+import 'package:static_shock/src/files.dart';
+import 'package:static_shock/src/pipeline.dart';
+import 'package:static_shock/src/static_shock.dart';
+
+class WebsiteScreenshotsPlugin extends StaticShockPlugin {
+  const WebsiteScreenshotsPlugin(this.screenshots);
+
+  final Set<WebsiteScreenshot> screenshots;
+
+  @override
+  void configure(StaticShockPipeline pipeline, StaticShockPipelineContext context) {
+    pipeline.loadData(
+      WebsiteScreenshotsDataLoader(screenshots),
+    );
+  }
+}
+
+class WebsiteScreenshotsDataLoader implements DataLoader {
+  const WebsiteScreenshotsDataLoader(this.screenshots);
+
+  final Set<WebsiteScreenshot> screenshots;
+
+  @override
+  Future<Map<String, Object>> loadData(StaticShockPipelineContext context) async {
+    final stopwatch = Stopwatch()..start();
+
+    final screenshotFutures = <Future>[];
+
+    print("Launching browser...");
+    final viewportSize = ViewportSize(width: 1280, height: 1024);
+    final browser = await puppeteer.launch(
+      headless: true,
+      defaultViewport: DeviceViewport(width: viewportSize.width, height: viewportSize.height),
+    );
+    print("Browser is launched.");
+    for (final screenshot in screenshots) {
+      print("Taking screenshot of: ${screenshot.url}");
+      screenshotFutures.add(_takeScreenshot(context, browser, viewportSize, screenshot));
+    }
+    await Future.wait(screenshotFutures);
+    browser.close();
+
+    stopwatch.stop();
+    print("Total screenshot time: ${stopwatch.elapsedMilliseconds.toDouble() / 1000}s");
+
+    return {};
+  }
+
+  Future<void> _takeScreenshot(
+    StaticShockPipelineContext context,
+    Browser browser,
+    ViewportSize viewport,
+    WebsiteScreenshot screenshot,
+  ) async {
+    final page = await browser.newPage();
+    await page.goto(screenshot.url.toString(), wait: Until.networkIdle);
+    final bitmap = await page.screenshot(
+      format: ScreenshotFormat.png,
+      fullPage: false,
+      clip: Rectangle(0, 0, viewport.width, viewport.height),
+    );
+    page.close();
+
+    final image = decodePng(bitmap)!;
+    final smallImage = copyResize(image, width: 256, interpolation: Interpolation.average);
+
+    context.addAsset(
+      Asset(
+        destinationPath: screenshot.output,
+        destinationContent: AssetContent.binary(
+          encodePng(smallImage),
+        ),
+      ),
+    );
+  }
+}
+
+class ViewportSize {
+  ViewportSize({
+    required this.width,
+    required this.height,
+  });
+
+  final int width;
+  final int height;
+
+  double get aspectRatio => width / height;
+
+  ViewportSize scaleToWidth(int newWidth) => ViewportSize(width: newWidth, height: (newWidth / aspectRatio).round());
+
+  ViewportSize scaleToHeight(int newHeight) =>
+      ViewportSize(width: (newHeight * aspectRatio).round(), height: newHeight);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ViewportSize && runtimeType == other.runtimeType && width == other.width && height == other.height;
+
+  @override
+  int get hashCode => width.hashCode ^ height.hashCode;
+}
+
+class WebsiteScreenshot {
+  const WebsiteScreenshot(this.id, this.url, this.output);
+
+  final String id;
+  final Uri url;
+  final FileRelativePath output;
+}

--- a/packages/static_shock/lib/static_shock.dart
+++ b/packages/static_shock/lib/static_shock.dart
@@ -2,6 +2,7 @@ library static_shock;
 
 // ----- Core constructs -----
 export 'src/assets.dart';
+export 'src/cache.dart';
 export 'src/data.dart';
 export 'src/files.dart';
 export 'src/finishers.dart';

--- a/packages/static_shock/lib/static_shock.dart
+++ b/packages/static_shock/lib/static_shock.dart
@@ -24,3 +24,4 @@ export 'src/plugins/redirects.dart';
 export 'src/plugins/rss.dart';
 export 'src/plugins/sass.dart';
 export 'src/plugins/tailwind_css.dart';
+export 'src/plugins/website_screenshots.dart';

--- a/packages/static_shock/pubspec.yaml
+++ b/packages/static_shock/pubspec.yaml
@@ -12,12 +12,14 @@ dependencies:
   fbh_front_matter: ^0.0.1
   github: ^9.24.0
   http: ^1.2.1
+  image: ^4.2.0
   intl: ^0.19.0
   jinja: ^0.6.0
   markdown: ^7.0.2
   mason_logger: ^0.2.5
   path: ^1.8.3
   pub_updater: ^0.4.0
+  puppeteer: ^3.12.0
   sass: ^1.62.1
   yaml: ^3.1.2
 

--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -167,6 +167,12 @@ class StaticShockDevServer {
   }
 
   Future<void> _onSourceFileChange(WatchEvent event) async {
+    if (event.path.contains(".shock")) {
+      // Don't track changes to the Static Shock cache so that `shock serve`
+      // doesn't get stuck in an endless build loop.
+      return;
+    }
+
     // WARNING: Don't log anything with mason_logger if we're already running a
     // build. Something is causing the logger to blow up. https://github.com/felangel/mason/issues/1280
     if (isBuilding) {

--- a/packages/static_shock_docs/.gitignore
+++ b/packages/static_shock_docs/.gitignore
@@ -1,6 +1,9 @@
 # Build output
 /build
 
+# Puppeteer cached output
+.local-chrome
+
 # Firebase
 /.firebase
 

--- a/packages/static_shock_docs/.gitignore
+++ b/packages/static_shock_docs/.gitignore
@@ -1,6 +1,9 @@
 # Build output
 /build
 
+# Shock cache and temp files
+/source/.shock/
+
 # Puppeteer cached output
 .local-chrome
 

--- a/packages/static_shock_docs/bin/static_shock_docs.dart
+++ b/packages/static_shock_docs/bin/static_shock_docs.dart
@@ -19,6 +19,53 @@ Future<void> main(List<String> arguments) async {
       showDrafts: arguments.contains("preview"),
     ))
     ..plugin(const PubPackagePlugin())
+    ..plugin(WebsiteScreenshotsPlugin({
+      WebsiteScreenshot(
+        "staticshock_io",
+        Uri.parse("https://staticshock.io"),
+        FileRelativePath("images/screenshots/", "staticshock_io", "png"),
+      ),
+      WebsiteScreenshot(
+        "superdeclarative_com",
+        Uri.parse("https://superdeclarative.com"),
+        FileRelativePath("images/screenshots/", "superdeclarative_com", "png"),
+      ),
+      WebsiteScreenshot(
+        "flutterbountyhunters_com",
+        Uri.parse("https://flutterbountyhunters.com"),
+        FileRelativePath("images/screenshots/", "flutterbountyhunters_com", "png"),
+      ),
+      WebsiteScreenshot(
+        "blog_flutterbountyhunters_com",
+        Uri.parse("https://blog.flutterbountyhunters.com"),
+        FileRelativePath("images/screenshots/", "blog_flutterbountyhunters_com", "png"),
+      ),
+      WebsiteScreenshot(
+        "flutterarbiter_com",
+        Uri.parse("https://flutterarbiter.com"),
+        FileRelativePath("images/screenshots/", "flutterarbiter_com", "png"),
+      ),
+      WebsiteScreenshot(
+        "flutterspaces_com",
+        Uri.parse("https://flutterspaces.com"),
+        FileRelativePath("images/screenshots/", "flutterspaces_com", "png"),
+      ),
+      WebsiteScreenshot(
+        "fluttershaders_com",
+        Uri.parse("https://fluttershaders.com"),
+        FileRelativePath("images/screenshots/", "fluttershaders_com", "png"),
+      ),
+      WebsiteScreenshot(
+        "flutter_test_robots",
+        Uri.parse("https://flutter-bounty-hunters.github.io/flutter_test_robots/"),
+        FileRelativePath("images/screenshots/", "docs_flutter_test_robots", "png"),
+      ),
+      WebsiteScreenshot(
+        "ffmpeg_cli",
+        Uri.parse("https://flutter-bounty-hunters.github.io/ffmpeg_cli/"),
+        FileRelativePath("images/screenshots/", "docs_ffmpeg_cli", "png"),
+      ),
+    }))
     ..plugin(const RssPlugin(
       site: RssSiteConfiguration(
         title: "Static Shock Docs",

--- a/packages/static_shock_docs/source/_data.yaml
+++ b/packages/static_shock_docs/source/_data.yaml
@@ -7,3 +7,63 @@ github:
   contributors:
     repositories:
       - { organization: flutter-bounty-hunters, name: static_shock }
+
+showcase:
+  screenshots:
+    marketing:
+      -
+        id: "staticshock_io"
+        title: "Static Shock"
+        url: "https://staticshock.io"
+        output: "/images/screenshots/staticshock_io.png"
+      -
+        id: "superdeclarative_com"
+        title: "SuperDeclarative!"
+        url: "https://superdeclarative.com"
+        output: "/images/screenshots/superdeclarative_com.png"
+      -
+        id: "flutterbountyhunters_com"
+        title: "Flutter Bounty Hunters"
+        url: "https://flutterbountyhunters.com"
+        output: "/images/screenshots/flutterbountyhunters_com.png"
+      -
+        id: "blog_flutterbountyhunters_com"
+        title: "FBH Blog"
+        url: "https://blog.flutterbountyhunters.com"
+        output: "/images/screenshots/blog_flutterbountyhunters_com.png"
+      -
+        id: "flutterarbiter_com"
+        title: "Flutter Arbiter"
+        url: "https://flutterarbiter.com"
+        output: "/images/screenshots/flutterarbiter_com.png"
+      -
+        id: "flutterspaces_com"
+        title: "Flutter Spaces"
+        url: "https://flutterspaces.com"
+        output: "/images/screenshots/flutterspaces_com.png"
+      -
+        id: "fluttershaders_com"
+        title: "Flutter Shaders"
+        url: "https://fluttershaders.com"
+        output: "/images/screenshots/fluttershaders_com.png"
+    docs:
+      -
+        id: "flutter_test_robots"
+        title: "Flutter Test Robots"
+        url: "https://flutter-bounty-hunters.github.io/flutter_test_robots/"
+        output: "/images/screenshots/docs_flutter_test_robots.png"
+      -
+        id: "ffmpeg_cli"
+        title: "FFMPEG CLI"
+        url: "https://flutter-bounty-hunters.github.io/ffmpeg_cli/"
+        output: "/images/screenshots/docs_ffmpeg_cli.png"
+      -
+        id: "golden_bricks"
+        title: "Golden Bricks"
+        url: "https://flutter-bounty-hunters.github.io/golden_bricks/"
+        output: "/images/screenshots/golden_bricks.png"
+      -
+        id: "dart_rss"
+        title: "Dart RSS"
+        url: "https://flutter-bounty-hunters.github.io/dart-rss/"
+        output: "/images/screenshots/dart_rss.png"

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -16,6 +16,8 @@ docs_menu:
     id: compile-tailwind
   - title: Draft Articles
     id: draft-articles
+  - title: Website Screenshots
+    id: website-screenshots
   - title: Use Remote CSS and JS
     id: use-remote-css-and-js
   - title: Create a Plugin

--- a/packages/static_shock_docs/source/guides/website-screenshots.md
+++ b/packages/static_shock_docs/source/guides/website-screenshots.md
@@ -1,0 +1,180 @@
+---
+title: Website Screenshots
+tags: drafting
+---
+## The website screenshot plugin
+With the `WebsiteScreenshotPlugin` you can take screenshots of websites, save those
+screenshots as images, and then display those screenshots in your website.
+
+An ideal use-case for this plugin is to create a "showcase" of your other websites,
+such as on a portfolio website.
+
+## Configure the plugin
+Add the `WebsiteScreenshotPlugin` to your `StaticShock` pipeline and configure the
+size of the final output image.
+
+```dart
+Future<void> main(List<String> arguments) async {
+  // Configure the static website generator.
+  final staticShock = StaticShock()
+    // ...existing configuration here...
+    ..plugin(const WebsiteScreenshotsPlugin(
+      outputWidth: 256,
+    ));
+
+  // Generate the static website.
+  await staticShock.generateSite();
+}
+```
+
+When building your website, a headless browser is launched to take screenshots of
+the websites you requested. The `WebsiteScreenshotsPlugin` has a default browser 
+viewport size, but if you'd like a different viewport size, you can provide that 
+as a plugin argument.
+
+```dart
+  ..plugin(const WebsiteScreenshotsPlugin(
+    viewportSize: const ViewportSize(width: 720, height: 1280)
+    outputWidth: 256,
+  ));
+```
+
+## Request screenshots directly
+If you know what screenshots you want to take within your Dart code, you can
+specify those screenshots directly, during plugin configuration.
+
+```dart
+Future<void> main(List<String> arguments) async {
+  // Configure the static website generator.
+  final staticShock = StaticShock()
+    // ...existing configuration here...
+    ..plugin(const WebsiteScreenshotsPlugin(
+      screenshots: {
+        WebsiteScreenshot(
+          id: "static_shock",
+          url: Uri.parse("https://staticshock.io"),
+          output: FileRelativePath("images/screenshots", "staticshock", "png"),
+        ),
+        WebsiteScreenshot(
+          id: "flutter_bounty_hunters",
+          url: Uri.parse("https://flutterbountyhunters.com"),
+          output: FileRelativePath("images/screenshots", "fbh", "png"),
+        ),
+      },
+      outputWidth: 256,
+    ));
+
+  // Generate the static website.
+  await staticShock.generateSite();
+}
+```
+
+The "id" of each screenshot is used to cache the screenshots between builds. Using the
+same "id" multiple times will result in later screenshots overwriting earlier screenshots
+in your request set.
+
+## Requesting screenshots from data files
+It's often more convenient to request screenshots from `_data.yaml` files than it is
+from Dart code. Your website probably includes template code that wants to display
+your screenshots. Your template code uses the data index to access information.
+Therefore, declaring your screenshots in the data index gives you a direct connection
+to your template code.
+
+You can define screenshots anywhere in your data that you choose. You're in charge
+of where it goes, how it's formatted, and how you load it into the website screenshot
+plugin.
+
+The following is one example for how you might request screenshots from your data.
+
+**/_data.yaml**
+```yaml
+showcase:
+  screenshots:
+    -
+      id: "staticshock_io"
+      title: "Static Shock"
+      url: "https://staticshock.io"
+      output: "/images/screenshots/staticshock_io.png"
+    -
+      id: "superdeclarative_com"
+      title: "SuperDeclarative!"
+      url: "https://superdeclarative.com"
+      output: "/images/screenshots/superdeclarative_com.png"
+    -
+      id: "flutterbountyhunters_com"
+      title: "Flutter Bounty Hunters"
+      url: "https://flutterbountyhunters.com"
+      output: "/images/screenshots/flutterbountyhunters_com.png"
+```
+
+Given the aforementioned `_data.yaml` definition, configure the plugin so that it
+loads this data.
+
+**/bin/main.dart:**
+```dart
+Future<void> main(List<String> arguments) async {
+  // Configure the static website generator.
+  final staticShock = StaticShock()
+    // ...existing configuration here...
+    ..plugin(const WebsiteScreenshotsPlugin(
+      selector: (context) {
+        final rootData = context.dataIndex.inheritDataForPath(DirectoryRelativePath("/"));
+        final showcase = rootData['showcase'];
+        if (showcase == null) {
+          return {};
+        }
+        if (showcase is! Map<String, dynamic>) {
+          return {};
+        }
+
+        final screenshots = <WebsiteScreenshot>{};
+        final screenshotsYaml = showcase['screenshots'] as List<dynamic>;
+
+        for (final screenshotYaml in screenshotsYaml) {
+          screenshots.add(
+            WebsiteScreenshot(
+              id: screenshotYaml['id'],
+              url: Uri.parse(screenshotYaml['url']),
+              output: FileRelativePath.parse(screenshotYaml['output']),
+            ),
+          );
+        }
+
+        return screenshots;
+      },
+      outputWidth: 256,
+    ));
+
+  // Generate the static website.
+  await staticShock.generateSite();
+}
+```
+
+The plugin `selector` finds the screenshot requests in the data index and feeds them
+to the screenshot plugin. At this point, those screenshots will be generated and saved
+when the website is built.
+
+However, the webpage template still needs to read this data and display the screenshots.
+Assume that a showcase is built on the index page.
+
+**/index.jinja:**
+```html
+<section style="max-width: 1200px; margin: auto; margin-bottom: 200px;">
+  <h2 style="text-align: center; text-transform: uppercase;">Showcase</h2>
+  <p style="text-align: center; color: rgba(255, 255, 255, 0.5);">My awesome websites.</p>
+  <ul style="list-style-type: none; margin: 0; padding: 0; text-align: center;">
+    {% for screenshot in showcase.screenshots %}
+    <li style="display: inline-block; margin: 0; padding: 0;">
+      <a href="{{ screenshot.url }}" target="_blank" title="{{ screenshot.title }}">
+        <img src="{{ screenshot.output }}" style="display: inline-block; border-radius: 4px; margin: 16px;">
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+```
+
+With the template code above, the webpage now displays the screenshots that were taken
+by the plugin, and were declared in `_data.yaml`.
+
+To see this approach in action, visit the [Static Shock homepage](/)

--- a/packages/static_shock_docs/source/index.jinja
+++ b/packages/static_shock_docs/source/index.jinja
@@ -173,6 +173,31 @@ Create a new static website project:
       }}
       </section>
 
+      <section style="max-width: 1200px; margin: auto; margin-bottom: 200px;">
+        <h2 style="text-align: center; text-transform: uppercase;">Showcase</h2>
+        <p style="text-align: center; color: rgba(255, 255, 255, 0.5);">Websites generated with Static Shock.</p>
+        <ul style="list-style-type: none; margin: 0; padding: 0; text-align: center;">
+          {% for screenshot in showcase.screenshots.marketing %}
+          <li style="display: inline-block; margin: 0; padding: 0;">
+            <a href="{{ screenshot.url }}" target="_blank" title="{{ screenshot.title }}">
+              <img src="{{ screenshot.output }}" style="display: inline-block; border-radius: 4px; margin: 16px;">
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+
+        <h3 style="margin-top: 72px; font-size: 24px; text-align: center; text-transform: uppercase;">Documentation Websites</h3>
+        <ul style="list-style-type: none; margin: 0; padding: 0; text-align: center;">
+          {% for screenshot in showcase.screenshots.docs %}
+          <li style="display: inline-block; margin: 0; padding: 0;">
+            <a href="{{ screenshot.url }}" target="_blank" title="{{ screenshot.title }}">
+              <img src="{{ screenshot.output }}" style="display: inline-block; border-radius: 4px; margin: 16px;">
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </section>
+
       <section style="max-width: 800px; margin: auto; margin-bottom: 200px;">
         <h2 style="text-align: center; text-transform: uppercase;">Contributors</h2>
         <p style="text-align: center; color: rgba(255, 255, 255, 0.5);">Built by the following contributors.</p>

--- a/template_sources/template_blog/.gitignore
+++ b/template_sources/template_blog/.gitignore
@@ -1,6 +1,12 @@
 # Build output
 /build
 
+# Shock cache and temp files
+/source/.shock/
+
+# Puppeteer cached output
+.local-chrome
+
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/

--- a/template_sources/template_docs_multi_page/.gitignore
+++ b/template_sources/template_docs_multi_page/.gitignore
@@ -1,6 +1,12 @@
 # Build output
 /build
 
+# Shock cache and temp files
+/source/.shock/
+
+# Puppeteer cached output
+.local-chrome
+
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/

--- a/template_sources/template_empty/.gitignore
+++ b/template_sources/template_empty/.gitignore
@@ -1,6 +1,12 @@
 # Build output
 /build
 
+# Shock cache and temp files
+/source/.shock/
+
+# Puppeteer cached output
+.local-chrome
+
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/


### PR DESCRIPTION
Add staticshock.io showcase, WebsiteScreenshotsPlugin, and a Static Shock build cache (Resolves #161)(Resolves #117)

The `WebsiteScreenshotsPlugin` takes screenshots for any number of websites that are requested.

Each plugin is given a `StaticShockCache` for caching files between builds, which was important to avoid very long build times when taking screenshots.

<img width="1529" alt="Screenshot 2024-08-14 at 4 45 24 PM" src="https://github.com/user-attachments/assets/f2880469-1104-453f-b18e-3b1efedb8503">
