### PR TITLE
Fix custom header id being overwritten

### DIFF
--- a/packages/static_shock/lib/src/plugins/markdown.dart
+++ b/packages/static_shock/lib/src/plugins/markdown.dart
@@ -177,8 +177,8 @@ class MarkdownPageRenderer implements PageRenderer {
     final contentHtml = markdownToHtml(
       page.destinationContent ?? page.sourceContent,
       blockSyntaxes: [
-        HeaderWithIdSyntax(),
         ..._renderOptions.blockSyntaxes,
+        HeaderWithIdSyntax(),
       ],
       inlineSyntaxes: _renderOptions.inlineSyntaxes,
       extensionSet: _renderOptions.extensionSet,


### PR DESCRIPTION
Example code with bug

```dart
import 'package:markdown/markdown.dart';
import 'package:static_shock/static_shock.dart';

Future<void> main(List<String> arguments) async {
  // Configure the static website generator.
  final StaticShock staticShock = StaticShock()
    // Here, you can directly hook into the StaticShock pipeline. For example,
    // you can copy an "images" directory from the source set to build set:
    ..pick(DirectoryPicker.parse("images"))
    // All 3rd party behavior is added through plugins, even the behavior
    // shipped with Static Shock.
    ..plugin(MarkdownPlugin(
      renderOptions: MarkdownRenderOptions(
        blockSyntaxes: [
          MyHeaderWithIdSyntax(),
        ],
      ),
    ))
    ..plugin(const JinjaPlugin())
    ..plugin(const PrettyUrlsPlugin())
    ..plugin(const RedirectsPlugin())
    ..plugin(const SassPlugin())
    ..plugin(DraftingPlugin(
      showDrafts: arguments.contains("preview"),
    ));

  // Generate the static website.
  await staticShock.generateSite();
}

class MyHeaderWithIdSyntax extends HeaderWithIdSyntax {
  @override
  Node parse(BlockParser parser) {
    final element = super.parse(parser) as Element;

    element.generatedId = element.children?.firstOrNull?.textContent
        .toLowerCase()
        .trim()
        .replaceAll(RegExp(r'[^\p{L}\p{N} -_]', unicode: true), '')
        .replaceAll(RegExp(r'\s'), '-');

    return element;
  }
}

```