### PR TITLE
[Docs] - Turn on screenshots plugin for CI again, use committed screenshot images instead of generating them.

### DIFF
--- a/packages/static_shock_docs/bin/static_shock_docs.dart
+++ b/packages/static_shock_docs/bin/static_shock_docs.dart
@@ -3,9 +3,6 @@ import 'dart:io';
 import 'package:static_shock/static_shock.dart';
 
 Future<void> main(List<String> arguments) async {
-  final isRunningInCI = arguments.contains("ci");
-  final isRunningLocally = !isRunningInCI;
-
   // Configure the static website generator.
   final staticShock = StaticShock()
     ..pick(DirectoryPicker.parse("images"))
@@ -22,6 +19,36 @@ Future<void> main(List<String> arguments) async {
       showDrafts: arguments.contains("preview"),
     ))
     ..plugin(const PubPackagePlugin())
+    ..plugin(WebsiteScreenshotsPlugin(
+      selector: (context) {
+        final rootData = context.dataIndex.inheritDataForPath(DirectoryRelativePath("/"));
+        final showcase = rootData['showcase'];
+        if (showcase == null) {
+          return {};
+        }
+        if (showcase is! Map<String, dynamic>) {
+          return {};
+        }
+
+        final screenshots = <WebsiteScreenshot>{};
+        final marketingScreenshotsYaml = showcase['screenshots']['marketing'] as List<dynamic>;
+        final docsScreenshotsYaml = showcase['screenshots']['docs'] as List<dynamic>;
+        final screenshotsYaml = List.from(marketingScreenshotsYaml)..addAll(docsScreenshotsYaml);
+
+        for (final screenshotYaml in screenshotsYaml) {
+          screenshots.add(
+            WebsiteScreenshot(
+              id: screenshotYaml['id'],
+              url: Uri.parse(screenshotYaml['url']),
+              output: FileRelativePath.parse(screenshotYaml['output']),
+            ),
+          );
+        }
+
+        return screenshots;
+      },
+      outputWidth: 256,
+    ))
     ..plugin(const RssPlugin(
       site: RssSiteConfiguration(
         title: "Static Shock Docs",
@@ -44,45 +71,6 @@ Future<void> main(List<String> arguments) async {
         "algolia_api_key": Platform.environment["STATIC_SHOCK_ALGOLIA_API_KEY"] ?? "",
       };
     }));
-
-  if (isRunningLocally) {
-    // Only run the website screenshot plugin locally. I discovered on Jan 12, 2025 that
-    // the puppeteer package was no longer able to start the headless browser in GitHub CI.
-    //
-    // Last working screenshot job: https://github.com/Flutter-Bounty-Hunters/static_shock/actions/runs/11989067921/job/33425027002
-    staticShock.plugin(
-      WebsiteScreenshotsPlugin(
-        selector: (context) {
-          final rootData = context.dataIndex.inheritDataForPath(DirectoryRelativePath("/"));
-          final showcase = rootData['showcase'];
-          if (showcase == null) {
-            return {};
-          }
-          if (showcase is! Map<String, dynamic>) {
-            return {};
-          }
-
-          final screenshots = <WebsiteScreenshot>{};
-          final marketingScreenshotsYaml = showcase['screenshots']['marketing'] as List<dynamic>;
-          final docsScreenshotsYaml = showcase['screenshots']['docs'] as List<dynamic>;
-          final screenshotsYaml = List.from(marketingScreenshotsYaml)..addAll(docsScreenshotsYaml);
-
-          for (final screenshotYaml in screenshotsYaml) {
-            screenshots.add(
-              WebsiteScreenshot(
-                id: screenshotYaml['id'],
-                url: Uri.parse(screenshotYaml['url']),
-                output: FileRelativePath.parse(screenshotYaml['output']),
-              ),
-            );
-          }
-
-          return screenshots;
-        },
-        outputWidth: 256,
-      ),
-    );
-  }
 
   // Generate the static website.
   await staticShock.generateSite();


### PR DESCRIPTION
[Docs] - Turn on screenshots plugin for CI again, use committed screenshot images instead of generating them.