### PR TITLE
[Docs] - Added references for Jinja and Markdown (Resolves #194)

### DIFF
--- a/packages/static_shock_docs/source/concepts/_data.yaml
+++ b/packages/static_shock_docs/source/concepts/_data.yaml
@@ -16,3 +16,27 @@ docs_menu:
           id: data-index
         - title: Pages Index
           id: pages-index
+        - title: Plugins
+          id: plugins
+    - title: Markdown
+      id: markdown
+      subPath: markdown/
+      items:
+        - title: Overview
+          id: overview
+    - title: Jinja Templates
+      id: jinja-templates
+      subPath: jinja-templates/
+      items:
+        - title: What is Jinja?
+          id: what-is-jinja
+        - title: Jinja Plugin
+          id: jinja-plugin
+        - title: Basic Syntax
+          id: basic-syntax
+        - title: Filters
+          id: filters
+        - title: Tests
+          id: tests
+        - title: Functions
+          id: functions

--- a/packages/static_shock_docs/source/concepts/how-it-works/plugins.md
+++ b/packages/static_shock_docs/source/concepts/how-it-works/plugins.md
@@ -1,0 +1,153 @@
+---
+title: Plugins
+---
+Plugins are a major part of Static Shock. Static Shock is designed to be as
+pluggable as possible, with the express purpose of empowering plugins.
+
+Static Shock ships with support for the following:
+ * Markdown parsing
+ * Jinja templating
+ * Sass compilation
+ * Tailwind compilation
+ * Pretty URLs
+ * Redirect generation
+ * RSS feeds
+ * Website screenshotting
+ * Pub package metadata scraping
+ * GitHub repository metadata scraping
+ * and more...
+
+Despite the fact that Static Shock ships these tools, each of these tools is
+implemented as it's own plugin. Each behavior is accomplished by registering
+these plugins with Static Shock.
+
+For example, the Dart file for this very website looks like the following.
+
+```dart
+final staticShock = StaticShock(
+    site: SiteMetadata(
+        rootUrl: 'https://staticshock.io',
+        basePath: '/',
+      ),
+    )
+    ..pick(DirectoryPicker.parse("images"))
+    ..plugin(const MarkdownPlugin())
+    ..plugin(JinjaPlugin(
+      filters: [
+        menuItemsWherePageExistsFilterBuilder,
+      ],
+    ))
+    ..plugin(const PrettyUrlsPlugin())
+    ..plugin(const RedirectsPlugin())
+    ..plugin(const SassPlugin())
+    ..plugin(DraftingPlugin(
+      showDrafts: arguments.contains("preview"),
+    ))
+    ..plugin(const PubPackagePlugin())
+    ..plugin(WebsiteScreenshotsPlugin(
+      selector: (context) {
+        // Implementation elided...
+      },
+      outputWidth: 256,
+    ))
+    ..plugin(const RssPlugin(
+      site: RssSiteConfiguration(
+        title: "Static Shock Docs",
+        description: "Documentation website for the static_shock package.",
+        homePageUrl: "https://staticshock.io",
+      ),
+    ))
+    ..plugin(
+      GitHubContributorsPlugin(
+        authToken: Platform.environment["GHUB_DOC_WEBSITE_TOKEN"],
+      ),
+    )
+    ..loadData(/*...*/);
+```
+
+Notice that nearly all of the Static Shock website's configuration is the
+selection and configuration of plugins.
+
+By shipping behaviors as plugins, Static Shock ensures that 3rd party developers
+will be able to access what they need to write their own plugins.
+
+Also, by shipping behaviors as plugins, developers enjoy the freedom to activate
+only the behaviors they need.
+
+## How do plugins work?
+Fundamentally, plugins are extremely simple. A plugin is essentially a function
+that's called by Static Shock. Inside that function, the plugin can register
+whatever pieces it wants.
+
+The interface for a plugin is as follows.
+
+```dart
+abstract class StaticShockPlugin {
+  const StaticShockPlugin();
+
+  /// ID that uniquely differentiates this plugin from all other plugins.
+  ///
+  /// The plugin ID is used, for example, to segregate caches for each plugin.
+  ///
+  /// One strategy to help avoid ID conflicts is to use a domain name that
+  /// you own, e.g., "com.mydomain.myplugin".
+  String get id;
+
+  /// Configures the [pipeline] to add new features that are associated with
+  /// this plugin.
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {}
+}
+```
+
+A plugin is defined entirely by what it chooses to register within its `configure()` method.
+
+The following is the implementation for the drafting plugin, which removes any pages
+that are in draft mode.
+
+```dart
+@override
+FutureOr<void> configure(
+  StaticShockPipeline pipeline,
+  StaticShockPipelineContext context,
+  StaticShockCache pluginCache,
+) {
+  pipeline.filterPages(
+    _DraftPageFilter(showDrafts: showDrafts),
+  );
+}
+```
+
+The following is the implementation of the Sass plugin, which compiles Sass files
+to CSS.
+
+```dart
+@override
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
+  final sassEnvironment = SassEnvironment(context.log);
+
+  pipeline
+    // Load all local Sass files as assets.
+    ..pick(ExtensionPicker("sass"))
+    ..pick(ExtensionPicker("scss"))
+    // Index all the loaded Sass files so they can import each other.
+    ..transformAssets(
+      SassIndexTransformer(context.log, sassEnvironment),
+    )
+    // Compile all Sass files to CSS.
+    ..transformAssets(
+      SassAssetTransformer(context.log, sassEnvironment),
+    );
+}
+```
+
+The objects that plugins register with Static Shock are the various hooks
+supported by the `StaticShockPipeline`. See [the pipeline](concepts/how-it-works/the-pipeline)
+documentation to learn more about pipeline steps and hooks.

--- a/packages/static_shock_docs/source/concepts/how-it-works/the-pipeline.md
+++ b/packages/static_shock_docs/source/concepts/how-it-works/the-pipeline.md
@@ -41,9 +41,6 @@ The Static Shock pipeline executes the following steps on each build:
 13. Run finishers
 14. Write all files to the destination directory
 
-When working on Static Shock, it's common to focus on just one of these
-steps. Tasks don't usually require modifying multiple pipeline steps.
-
 The Static Shock pipeline might appear to include a lot of steps, but the
 reason for so many steps is to make Static Shock as pluggable as possible.
 As such, most Static Shock development can happen inside of plugins, instead

--- a/packages/static_shock_docs/source/concepts/jinja-templates/basic-syntax.md
+++ b/packages/static_shock_docs/source/concepts/jinja-templates/basic-syntax.md
@@ -1,0 +1,76 @@
+---
+title: Basic Syntax
+---
+Jinja includes a variety of syntax options, which are fully documented on the
+[Jinja website](https://jinja.palletsprojects.com/en/stable/).
+
+Static Shock uses the [Jinja package from Pub](https://pub.dev/packages/jinja),
+which may not support all Jinja syntax features.
+
+You should refer to the above references for complete Jinja documentation.
+
+To aid with Static Shock development, some key syntax examples are documented here.
+
+## Statement Bounds
+Generally speaking, anything that appears between a `{{` and a `}}` will be
+interpreted by Jinja as a Jinja statement.
+
+## Variables
+Variable replacement occurs by naming the variable in a Jinja statement.
+
+```
+The following variable will be replaced: {{ someVar }}.
+```
+
+## Comments
+Comments are often useful when writing obtuse template code. In Jinja, comments
+are encoded as blocks (not lines). A comment block begins with `{#` and ends with
+`#}`.
+
+```
+{# This is an explanation of something #}
+Hello, {{ someVar }}!
+```
+
+Comments don't just hide Jinja code. They hide whatever content appears between
+them, even if that code happens to be HTML.
+
+```
+{# None of the content here will appear in the output file
+  <section>
+    <nav>
+    </nav>
+  </section>
+}#
+```
+
+## Escape Block
+It's common for Jinja syntax to appear in regular content. For example, every code
+sample on this page obviously includes Jinja syntax. Therefore, it's important to
+remember how to avoid parsing Jinja.
+
+Tell Jinja to ignore a block of text by surrounding it with `{% raw %}` and
+`{% endraw %}`.
+
+```
+{% raw %}
+<p>None of the Jinja synax in this code sample will be processed by Jinja.</p>
+<pre><code>
+  <nav>
+    <ul>
+    {% for item in menuItem.items %}
+      <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
+    {% endfor %}
+    </ul>
+  </nav>
+</code></pre>
+{% endraw %}
+```
+
+## Conditionals
+
+## Loops
+
+## Filters
+
+## Tests

--- a/packages/static_shock_docs/source/concepts/jinja-templates/filters.md
+++ b/packages/static_shock_docs/source/concepts/jinja-templates/filters.md
@@ -1,0 +1,30 @@
+---
+title: Filters
+---
+Filters are functions that take an input value and then return an output value.
+
+The syntax for a typical filter is `{{ someVariable | my_filter }}`. Some filters
+require additional information to do their job. In that case, the filter can receive
+arguments like a typical function call, `{{ someVariable | my_filter(arg1, arg2) }}`.
+
+For example, the following illustrate string manipulation with filters.
+
+```
+<h1>{{ title | upper }}</h1>
+<p>{{ summary | capitalize }}</p>
+<p>{{ "hello world" | title }}</p>
+<p>{{ name | lower }}</p>
+<p>{{ text | truncate(20) }}</p>
+<p>{{ filename | replace('.txt', '.csv') }}</p>
+```
+
+### Available Filters
+The official distribution of Jinja includes a number of [built-in filters](https://jinja.palletsprojects.com/en/stable/templates/#builtin-filters).
+
+Static Shock uses a [Pub package for Jinja](https://pub.dev/packages/jinja) support, which may or may not support all standard filters.
+
+Static Shock adds some of its own filters, making them available to every `Page` template.
+ * `local_link`, which creates an absolute URL path for the given local path. E.g., "guides/welcome/" might become "/static_shock/guides/welcome/". Example: `{{ "guides/welcome/" | local_link }}`.
+ * `formatDateTime`, which parses the incoming date, and then returns it in another date format. Example: `{{ "2022-12-28" | formatDateTime(to = "MMMM dd, yyyy") }}`.
+ * `take`, which takes and returns up to the given number of items from a given iterable variable. Example: `{{ for contribute in contributors | take(4) }}`.
+ * `pathRelativeToPage`, which returns a new path built from the current `Page`'s path, and the given sub-path. Example: `{{ "images/header.png" | pathRelativeToPath }}`.

--- a/packages/static_shock_docs/source/concepts/jinja-templates/functions.md
+++ b/packages/static_shock_docs/source/concepts/jinja-templates/functions.md
@@ -1,0 +1,23 @@
+---
+title: Functions
+---
+Jinja supports calling out to standalone Dart functions.
+
+Jinja functions can use position parameters.
+
+```
+{{ cycle("odd", "even") }}
+```
+
+Jinja functions also support named parameters.
+
+```
+{{ print("Hello, world!", level="verbose") }}
+```
+
+### Available Functions
+The official distribution of Jinja includes a number of [built-in functions](https://jinja.palletsprojects.com/en/stable/templates/#list-of-global-functions).
+
+Static Shock uses a [Pub package for Jinja](https://pub.dev/packages/jinja) support, which may or may not support all standard functions.
+
+Static Shock currently doesn't add any custom functions, but may in the future.

--- a/packages/static_shock_docs/source/concepts/jinja-templates/jinja-plugin.md
+++ b/packages/static_shock_docs/source/concepts/jinja-templates/jinja-plugin.md
@@ -1,0 +1,32 @@
+---
+title: Jinja Plugin
+---
+Jinja template support is added to a Static Shock website by applying the
+`JinjaPlugin`.
+
+```dart
+final site = StaticShock()
+  ..plugin(JinjaPlugin());
+```
+
+Once the Jinja plugin is applied, the plugin finds and picks every Jinja
+file in the source directory, as determined by the extension. Jinja is
+typically used to create layout and component files. It can also be used
+to create a traditional HTML page, with templating.
+
+```
+/source
+  /_includes
+    /components
+      navbar.jinja
+    /layouts
+      guide.jinja
+  /guides
+    welcome.md
+  contact.jinja
+  index.jinja
+```
+
+The value of Jinja templates within HTML is that a single HTML file can be
+used to render an infinite number of pages, because the template values
+change for every page.

--- a/packages/static_shock_docs/source/concepts/jinja-templates/tests.md
+++ b/packages/static_shock_docs/source/concepts/jinja-templates/tests.md
@@ -1,0 +1,49 @@
+---
+title: Tests
+---
+A test is a function that runs against some value or variable and returns
+`true` and `false`.
+
+Example of a test called `divisibleby`:
+```
+{% if myNumber is divisibleby 3 %}
+{% if myNumber is divisibleby(3) %}
+```
+
+As shown in the example, the keyword `is` is used to evaluate a test (or
+any other boolean expression).
+
+### Syntax Examples
+The following example shows a variety of boolean conditions, including some
+tests, which may help to understand Jinja syntax related to boolean expressions.
+
+```
+{% if category == 'news' %}
+  <p>Displaying news articles...</p>
+{% elif items is sequence and items|length > 5 %}
+  <p>Displaying a long list of items...</p>
+{% elif user.is_logged_in %}
+  <p>Welcome back, user!</p>
+{% else %}
+  <p>Please log in.</p>
+{% endif %}
+```
+
+Jinja also includes explicit syntax for negating boolean conditions.
+
+```
+{% if not items is empty %}
+  <p>The list of items is not empty.</p>
+{% endif %}
+
+{% if value is not none %}
+  <p>The value is not None.</p>
+{% endif %}
+```
+
+### Available Tests
+The official distribution of Jinja includes a number of [built-in tests](https://jinja.palletsprojects.com/en/stable/templates/#tests).
+
+Static Shock uses a [Pub package for Jinja](https://pub.dev/packages/jinja) support, which may or may not support all standard tests.
+
+Static Shock currently doesn't add any custom tests, but may in the future.

--- a/packages/static_shock_docs/source/concepts/jinja-templates/what-is-jinja.md
+++ b/packages/static_shock_docs/source/concepts/jinja-templates/what-is-jinja.md
@@ -1,0 +1,75 @@
+---
+title: What is Jinja?
+contentRenderers:
+  - jinja
+  - markdown
+---
+Jinja is a templating system which is included with Static Shock.
+
+Jinja is similar in purpose to may other templating systems such as Mustache,
+Handlebars, Nunjuck, and Vento. Static Shock avoided Mustache and Handlebars
+because those systems seemed too simplistic. Static Shock chose Jinja over
+Nunjuck and Vento because there were no good Pub packages that implemented
+those syntaxes.
+
+Jinja was originally developed as a [Python library](https://jinja.palletsprojects.com/en/stable/).
+
+A port of Jinja is [available on Pub](https://pub.dev/packages/jinja).
+
+## What are templates?
+Technically, a template is any text file that includes templating syntax.
+
+For example, the following snippet would replace "location" with some value,
+such as "world".
+
+{% raw %}
+```
+Hellow, {{ location }}!
+```
+{% endraw %}
+
+In practice, when we talk about templates in Static Shock, we're referring to
+HTML files where we want to insert values, execute loops, and run other template
+behaviors.
+
+For example, in an HTML file, a developer might want the title to be configurable
+so that it's easy to change.
+
+{% raw %}
+```
+<html>
+  <head>
+    <title>{{ title }}</title>
+  </head>
+</html
+```
+{% endraw %}
+
+Similarly, a developer might want to generate a navigation menu from data that's
+provided by a static site generator.
+
+{% raw %}
+```
+<nav>
+  <ul>
+  {% for item in menuItem.items %}
+    <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
+  {% endfor %}
+  </ul>
+</nav>
+```
+{% endraw %}
+
+## What can Jinja do?
+Jinja supports a variety of templating behaviors.
+
+The most basic behavior is replacement. When a template refers to a variable that's
+defined in the template environment, Jinja replaces the variable with the actual value.
+
+Jinja provides a few execution controls including loops and conditionals.
+
+Jinja can call out to Dart functions using what Jinja calls "filters". Learn more about
+the [filters that ship with Static Shock]({{ "concepts/jinja-templates/filters" | local_link }}).
+
+Jinja can call out to Dart boolean checks with what Jinja calls "tests". Learn more about
+the [tests that ship with Static Shock]({{ "concepts/jinja-templates/tests" | local_link }}).

--- a/packages/static_shock_docs/source/concepts/markdown/overview.md
+++ b/packages/static_shock_docs/source/concepts/markdown/overview.md
@@ -1,0 +1,64 @@
+---
+title: Overview
+contentRenderers:
+  - jinja
+  - markdown
+---
+Markdown is a [popular document markup format](https://www.markdownguide.org/basic-syntax/), 
+which is easy to read and write.
+
+Markdown is used in popular apps, including GitHub issues and PRs, Obsidian,
+Bear, Linear, and more. It's a great tradeoff between control over styling,
+ease of writing, and ease of reading.
+
+Static Shock supports Markdown as its primary content writing format.
+
+## Add the Plugin
+To use Markdown in your static site, add the `MarkdownPlugin` to your
+`StaticShock`.
+
+{% raw %}
+```dart
+final site = StaticShock()
+  ..plugin(const MarkdownPlugin());
+```
+{% endraw %}
+
+The Markdown plugin finds and picks every Markdown file it can find in the
+source directory. Markdown files are identified by a `.md` extension.
+
+{% raw %}
+```
+/source
+  /guides
+    welcome.md
+  index.md
+```
+{% endraw %}
+
+## Frontmatter
+Markdown isn't enough on its own. Authors need to be able to specify the title
+for a given page, as well as select a layout. It's also common to add a publish
+date and other metadata, too.
+
+Static Shock supports a syntax called "Frontmatter", which appears before the actual
+Markdown content. Frontmatter begins with "---" and ends with "---". In between, authors
+can write YAML to specify page metadata.
+
+{% raw %}
+```
+---
+title: Welcome
+publishDate: 2025-05-12
+layout: layouts/guide.jinja
+---
+# Welcome
+This is a welcome guide. This content below the "---" is Markdown.
+The content between the "---"'s is YAML metadata.
+
+The YAML metadata is provided to the templating system when this
+page is rendered, such as provided to a Jinja template.
+```
+{% endraw %}
+
+To render a Markdown page, see the [Jinja references]({{ "concepts/jinja-templates/what-is-jinja" | local_link }}).


### PR DESCRIPTION
[Docs] - Added references for Jinja and Markdown (Resolves #194)

Docs are added to `/concepts/jinja-templates/` and `/concepts/markdown/`.