### PR TITLE
Add LinksPlugin to validate all anchor tag links in website (Resolves #183)

### DIFF
--- a/packages/static_shock/lib/src/data.dart
+++ b/packages/static_shock/lib/src/data.dart
@@ -64,6 +64,10 @@ class DataIndex {
 
   final _DataNode _data;
 
+  /// Returns this website's base path, which is typically "/", but might be different
+  /// in some web server environments, such as GitHub Pages.
+  String get basePath => getAtPath(["basePath"]) as String;
+
   /// Returns all data from the global index that should be available to a page at the given [path].
   ///
   /// The global data index is a tree. The data that's made available to a given [path] includes all

--- a/packages/static_shock/lib/src/plugins/drafting.dart
+++ b/packages/static_shock/lib/src/plugins/drafting.dart
@@ -23,13 +23,16 @@ import 'package:static_shock/src/static_shock.dart';
 /// To preview draft content, build the website with [showDrafts] set to `true`.
 class DraftingPlugin implements StaticShockPlugin {
   const DraftingPlugin({
-    this.showDrafts = false,
+    this.showDrafts,
   });
 
   @override
   final id = "io.staticshock.drafting";
 
-  final bool showDrafts;
+  /// `true` to show draft articles, `false` to exclude drafts, or `null`
+  /// to let the CLI arguments configure it - defaults to `false` if no
+  /// CLI arguments are included.
+  final bool? showDrafts;
 
   @override
   FutureOr<void> configure(
@@ -38,7 +41,9 @@ class DraftingPlugin implements StaticShockPlugin {
     StaticShockCache pluginCache,
   ) {
     pipeline.filterPages(
-      _DraftPageFilter(showDrafts: showDrafts),
+      _DraftPageFilter(
+        showDrafts: context.cliArguments.contains("--preview"),
+      ),
     );
   }
 }

--- a/packages/static_shock/lib/src/plugins/jinja.dart
+++ b/packages/static_shock/lib/src/plugins/jinja.dart
@@ -167,8 +167,7 @@ class JinjaPageRenderer implements PageRenderer {
     required String templateSource,
     String? content,
   }) {
-    // TODO: create an accessor on the context for the base path
-    final basePath = context.dataIndex.getAtPath(["basePath"]) as String;
+    final basePath = context.dataIndex.basePath;
 
     final jinjaFilters = Map.fromEntries([
       MapEntry(

--- a/packages/static_shock/lib/src/plugins/links.dart
+++ b/packages/static_shock/lib/src/plugins/links.dart
@@ -1,0 +1,338 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:http/http.dart';
+import 'package:static_shock/src/cache.dart';
+import 'package:static_shock/src/files.dart';
+import 'package:static_shock/src/finishers.dart';
+import 'package:static_shock/src/pipeline.dart';
+import 'package:static_shock/src/static_shock.dart';
+
+/// A [StaticShockPlugin] that adds various link behaviors, such as finding
+/// bad links in the final website build.
+class LinksPlugin implements StaticShockPlugin {
+  const LinksPlugin({
+    this.shouldRunLinkVerification,
+    this.failBuildOnBrokenLinks = false,
+  });
+
+  /// Whether this plugin should verify all links, or not, or `null` to let
+  /// this plugin decide whether to verify links based on the website build
+  /// mode, e.g., dev vs production.
+  final bool? shouldRunLinkVerification;
+
+  /// Whether to report a build failure if any broken links are found.
+  ///
+  /// The functional difference is that when this property is `true`, broken
+  /// links are reported to Static Shock as errors, rather than warnings.
+  final bool failBuildOnBrokenLinks;
+
+  @override
+  String get id => "io.staticshock.links";
+
+  @override
+  FutureOr<void> configure(
+    StaticShockPipeline pipeline,
+    StaticShockPipelineContext context,
+    StaticShockCache pluginCache,
+  ) {
+    if (true == shouldRunLinkVerification ||
+        (shouldRunLinkVerification == null && context.buildMode == StaticShockBuildMode.dev)) {
+      pipeline.finish(
+        BrokenLinkFinderFinisher(
+          reportBrokenLinksAsErrors: failBuildOnBrokenLinks,
+        ),
+      );
+    }
+  }
+}
+
+class BrokenLinkFinderFinisher implements Finisher {
+  const BrokenLinkFinderFinisher({
+    this.reportBrokenLinksAsErrors = false,
+  });
+
+  /// Whether to report broken links as errors, rather than warnings.
+  ///
+  /// Errors are typically handled as build failures, whereas warnings still
+  /// report a successful build.
+  final bool reportBrokenLinksAsErrors;
+
+  @override
+  Future<void> execute(StaticShockPipelineContext context) async {
+    context.log.info("Validating all external and internal links in the built website.");
+
+    final linkFinder = HtmlLinkFinder();
+    final urlValidator = UrlValidator();
+    final thisSiteBaseUrl = context.dataIndex.inheritDataForPath(DirectoryRelativePath("/"))["baseUrl"] as String?;
+    final thisSiteBaseUri = thisSiteBaseUrl != null && thisSiteBaseUrl.isNotEmpty //
+        ? Uri.parse(thisSiteBaseUrl)
+        : null;
+
+    final checkedExternalUrls = <Uri>{};
+    int badExternalUrlCount = 0;
+    final checkedInternalUris = <Uri>{};
+    int badInternalUriCount = 0;
+    final errorLevel = reportBrokenLinksAsErrors ? StaticShockErrorLevel.error : StaticShockErrorLevel.warning;
+    for (final page in context.pagesIndex.pages) {
+      print("Scraping links page from: ${page.pagePath}");
+      if (page.tags.contains("drafting")) {
+        print(" - skipping this page because it's in draft mode");
+        continue;
+      }
+
+      final links = linkFinder //
+          .findAnchorLinks(page.destinationContent!)
+          .normalizeUris();
+
+      // Validate URLs that are expected to be live on the internet.
+      final externalUrls = links.whereRemote(thisSiteBaseUri).removeAll(checkedExternalUrls).toList(growable: false);
+      checkedExternalUrls.addAll(externalUrls);
+      final badExternalUrls = await urlValidator.findDeadUrls(externalUrls);
+      for (final badUrl in badExternalUrls) {
+        context.errorLog
+            .log(errorLevel, "Bad external URL found on page '${page.pagePath}' (${page.title}): '$badUrl'");
+        badExternalUrlCount += 1;
+      }
+
+      // Validate URLs and paths within this website, which probably are not live yet.
+      final internalUris = links
+          .whereLocal(thisSiteBaseUri)
+          .resolveRelative(page.pagePath!)
+          .removeAll(checkedInternalUris)
+          .toList(growable: true);
+      checkedInternalUris.addAll(internalUris);
+      for (final otherPage in context.pagesIndex.pages) {
+        print("Another page with URL: ${otherPage.makeUrl(context.dataIndex.basePath)}");
+        internalUris.removeWhere((internalUri) =>
+            // Check for trailing and non-trailing "/", e.g., "/guides/getting-started"
+            // and "/guides/getting-started/".
+            otherPage.makeUrl(context.dataIndex.basePath)! == internalUri.path ||
+            otherPage.makeUrl(context.dataIndex.basePath)! == "${internalUri.path}/");
+      }
+      final badInternalUris = internalUris;
+      for (final badInternalUri in badInternalUris) {
+        context.errorLog.log(
+            errorLevel, "Bad internal URL/path found on page '${page.pagePath}' (${page.title}): '$badInternalUri'");
+        badInternalUriCount += 1;
+      }
+    }
+
+    if (badExternalUrlCount == 0 && badInternalUriCount == 0) {
+      context.log.detail("All links look good!");
+    } else {
+      context.log.warn("Found $badExternalUrlCount bad external URLs, and $badInternalUriCount bad internal URIs.");
+    }
+  }
+}
+
+extension NormalizeUris on Iterable<Uri> {
+  Iterable<Uri> normalizeUris() => map(_normalizeUri);
+
+  Uri _normalizeUri(Uri uri) {
+    late final Uri url;
+    if (uri.host.isNotEmpty) {
+      // This URI is a URL.
+      url = uri;
+    } else if (_looksLikeDomain(uri)) {
+      final tryUrl = Uri.tryParse("https://${uri.path}");
+      if (tryUrl == null || tryUrl.host.isEmpty) {
+        // This is a path, e.g., "/guides/getting-started". There's nothing to
+        // normalize for a path.
+        return uri;
+      }
+
+      // This URI is a URL.
+      url = tryUrl;
+    } else {
+      // This URI has no host and doesn't look like a domain. It must
+      // be a path. There's nothing to normalize for a path.
+      return uri;
+    }
+
+    // We have a URL. Restructure it so that all of our URLs are represented
+    // in a comparable way.
+    return uri.replace(
+      scheme: "https",
+      host: uri.host.replaceFirst(RegExp(r'^www\.'), ""),
+    );
+  }
+
+  bool _looksLikeDomain(Uri uri) {
+    // No scheme or host, and path resembles a domain (e.g. www.flutter.dev)
+    final path = uri.path;
+    return !uri.hasScheme && //
+        uri.host.isEmpty &&
+        !path.startsWith('/') &&
+        RegExp(r'^[^/\s]+\.[^/\s]+$').hasMatch(path);
+  }
+}
+
+/// Inspects HTML and extracts all link [Uri]s that can be found.
+class HtmlLinkFinder {
+  static final _anchorRegExp = RegExp(r'<a\b[^>]*>(.*?)<\/a>', caseSensitive: false, dotAll: true);
+  static final _urlFromAnchor = RegExp('href\\s*=\\s*["\\\']([^"\\\']+)["\\\']', caseSensitive: false);
+
+  List<Uri> findAnchorLinks(String html) {
+    final uris = <Uri>[];
+
+    final anchors = _anchorRegExp.allMatches(html);
+    for (final anchorMatch in anchors) {
+      final anchor = anchorMatch.group(0);
+      if (anchor == null) {
+        continue;
+      }
+
+      final links = _urlFromAnchor.firstMatch(anchor)?.group(1);
+      if (links != null && !links.startsWith("#")) {
+        uris.add(Uri.parse(links));
+      }
+    }
+
+    return uris;
+  }
+}
+
+/// Validates given URLs, such as pinging the URL to see if it returns a good status code.
+class UrlValidator {
+  /// Pings each URL in [links] and returns all [Uri]s that fail the ping.
+  Future<List<Uri>> findDeadUrls(List<Uri> links) async {
+    final urls = links.where((link) => link.hasScheme);
+
+    final badUrls = <Uri>[];
+    final urlChecks = <Future<Object>>[
+      for (final url in urls) //
+        () async {
+          try {
+            return await get(url);
+          } catch (exception) {
+            return url;
+          }
+        }(),
+    ];
+    final responses = await Future.wait(urlChecks);
+    for (final response in responses) {
+      if (response is Uri) {
+        // An exception was thrown when calling the URL. What was returned was
+        // the URL so we can report it as bad.
+        badUrls.add(response);
+        continue;
+      }
+
+      if (response is! Response) {
+        throw Exception("We expected an HTTP Response but got a ${response.runtimeType}");
+      }
+      if (200 <= response.statusCode && response.statusCode < 400) {
+        // This URL is fine.
+        continue;
+      }
+
+      badUrls.add(response.request!.url);
+    }
+
+    return badUrls;
+  }
+}
+
+extension GroupRemoval on Iterable<Uri> {
+  Iterable<Uri> removeAll(Iterable<Uri> blacklist) => whereNot((item) => blacklist.contains(item));
+}
+
+extension UriSelector on Iterable<Uri> {
+  Iterable<Uri> whereLocal(Uri? thisSiteBaseUri) {
+    return whereNot(_selectRemoteUrls(thisSiteBaseUri));
+  }
+
+  Iterable<Uri> resolveRelative(String currentPagePath) {
+    return map((uri) {
+      if (uri.path.startsWith("/")) {
+        return uri;
+      }
+
+      print(
+          "Relative URI - source page: $currentPagePath, from: ${uri.path}, to: ${Uri.parse("$currentPagePath${uri.path}")}");
+      return Uri.parse("$currentPagePath${uri.path}");
+    });
+  }
+
+  Iterable<Uri> whereRemote(Uri? thisSiteBaseUri) {
+    return where(_selectRemoteUrls(thisSiteBaseUri));
+  }
+
+  bool Function(Uri) _selectRemoteUrls(Uri? thisSiteBaseUri) {
+    return (link) {
+      if (thisSiteBaseUri == null) {
+        // We don't know the base URL, so we can't find URLs pointing to this
+        // site. However, all paths implicitly point to this site. Select based
+        // on path.
+
+        if (link.host.isNotEmpty) {
+          // This is a URL, we assume it's pointing somewhere else.
+          return true;
+        }
+
+        if (_looksLikeDomain(link)) {
+          final asUrl = Uri.tryParse("https://${link.path}");
+          if (asUrl != null && asUrl.host.isNotEmpty) {
+            // This is a URL without a scheme, e.g., "flutter.dev". We assume
+            // it's pointing somewhere else.
+            return true;
+          }
+        }
+
+        // This is a path - no scheme, no host - it points somewhere within
+        // this website.
+        return false;
+      }
+
+      // At this point, we know the site base URI is non-null.
+      //
+      // Ensure the base URI is encoded as a URL so that we can correctly compare
+      // URL components.
+      final thisSiteBaseUrl = thisSiteBaseUri.host.isNotEmpty ? thisSiteBaseUri : Uri.parse("https://$thisSiteBaseUri");
+
+      if (link.host.isNotEmpty && !_hasSameHost(link, thisSiteBaseUrl)) {
+        // This link is a URL with a scheme and it points to some other website.
+        return true;
+      }
+
+      if (_looksLikeDomain(link)) {
+        final asUrl = Uri.tryParse("https://${link.path}");
+        if (asUrl != null && asUrl.host.isNotEmpty && !_hasSameHost(asUrl, thisSiteBaseUrl)) {
+          // This link is a URL without a scheme, e.g., "flutter.dev", and it points
+          // to another website.
+          return true;
+        }
+      }
+
+      // This link is either a URL that points to this website, or an internal
+      // page path.
+      return false;
+    };
+  }
+
+  bool _hasSameHost(Uri a, Uri b) {
+    if (a.host.toLowerCase() == b.host.toLowerCase()) {
+      return true;
+    }
+
+    // Handle case where one has "www" but the other doesn't.
+    final findWWW = RegExp(r"www\.", caseSensitive: false);
+    if (a.host.startsWith(findWWW)) {
+      return a.host.substring(4) == b.host;
+    } else if (b.host.startsWith(findWWW)) {
+      return b.host.substring(4) == a.host;
+    }
+
+    return false;
+  }
+
+  bool _looksLikeDomain(Uri uri) {
+    // No scheme or host, and path resembles a domain (e.g. www.flutter.dev)
+    final path = uri.path;
+    return !uri.hasScheme && //
+        uri.host.isEmpty &&
+        !path.startsWith('/') &&
+        RegExp(r'^[^/\s]+\.[^/\s]+$').hasMatch(path);
+  }
+}

--- a/packages/static_shock/lib/src/plugins/links.dart
+++ b/packages/static_shock/lib/src/plugins/links.dart
@@ -75,9 +75,7 @@ class BrokenLinkFinderFinisher implements Finisher {
     int badInternalUriCount = 0;
     final errorLevel = reportBrokenLinksAsErrors ? StaticShockErrorLevel.error : StaticShockErrorLevel.warning;
     for (final page in context.pagesIndex.pages) {
-      print("Scraping links page from: ${page.pagePath}");
       if (page.tags.contains("drafting")) {
-        print(" - skipping this page because it's in draft mode");
         continue;
       }
 
@@ -103,7 +101,6 @@ class BrokenLinkFinderFinisher implements Finisher {
           .toList(growable: true);
       checkedInternalUris.addAll(internalUris);
       for (final otherPage in context.pagesIndex.pages) {
-        print("Another page with URL: ${otherPage.makeUrl(context.dataIndex.basePath)}");
         internalUris.removeWhere((internalUri) =>
             // Check for trailing and non-trailing "/", e.g., "/guides/getting-started"
             // and "/guides/getting-started/".
@@ -152,7 +149,7 @@ extension NormalizeUris on Iterable<Uri> {
 
     // We have a URL. Restructure it so that all of our URLs are represented
     // in a comparable way.
-    return uri.replace(
+    return url.replace(
       scheme: "https",
       host: uri.host.replaceFirst(RegExp(r'^www\.'), ""),
     );
@@ -249,9 +246,11 @@ extension UriSelector on Iterable<Uri> {
         return uri;
       }
 
-      print(
-          "Relative URI - source page: $currentPagePath, from: ${uri.path}, to: ${Uri.parse("$currentPagePath${uri.path}")}");
-      return Uri.parse("$currentPagePath${uri.path}");
+      if (currentPagePath.endsWith("/")) {
+        return Uri.parse("$currentPagePath${uri.path}");
+      } else {
+        return Uri.parse("$currentPagePath/${uri.path}");
+      }
     });
   }
 

--- a/packages/static_shock/lib/src/plugins/menus.dart
+++ b/packages/static_shock/lib/src/plugins/menus.dart
@@ -71,7 +71,13 @@ List _pageExistsForMenuItem(
   final filteredMenuItems = <Object>[];
   for (final menuItem in menuItems) {
     final pathFragments = [...prefixPathFragments, menuItem['id']];
-    final pagePath = pathFragments.isNotEmpty ? "${pathFragments.join("/")}/" : "";
+    print("Menu item: $menuItem, prefix path fragments: $prefixPathFragments");
+    print(" - last path fragment: '${prefixPathFragments.last}'");
+    print(" - does last path fragment end with '/'? ${(prefixPathFragments.last as String).endsWith("/")}");
+    final pagePath = pathFragments.isNotEmpty && !(prefixPathFragments.last as String).endsWith("/")
+        ? "${pathFragments.join("/")}/"
+        : "";
+    print(" - page path: $pagePath");
     for (final page in context.pagesIndex.pages) {
       if (page.pagePath == pagePath) {
         filteredMenuItems.add(menuItem);

--- a/packages/static_shock/lib/src/plugins/menus.dart
+++ b/packages/static_shock/lib/src/plugins/menus.dart
@@ -71,13 +71,9 @@ List _pageExistsForMenuItem(
   final filteredMenuItems = <Object>[];
   for (final menuItem in menuItems) {
     final pathFragments = [...prefixPathFragments, menuItem['id']];
-    print("Menu item: $menuItem, prefix path fragments: $prefixPathFragments");
-    print(" - last path fragment: '${prefixPathFragments.last}'");
-    print(" - does last path fragment end with '/'? ${(prefixPathFragments.last as String).endsWith("/")}");
     final pagePath = pathFragments.isNotEmpty && !(prefixPathFragments.last as String).endsWith("/")
         ? "${pathFragments.join("/")}/"
         : "";
-    print(" - page path: $pagePath");
     for (final page in context.pagesIndex.pages) {
       if (page.pagePath == pagePath) {
         filteredMenuItems.add(menuItem);

--- a/packages/static_shock/lib/static_shock.dart
+++ b/packages/static_shock/lib/static_shock.dart
@@ -15,6 +15,7 @@ export 'src/templates/layouts.dart';
 export 'src/plugins/drafting.dart';
 export 'src/plugins/github.dart';
 export 'src/plugins/jinja.dart';
+export 'src/plugins/links.dart';
 export 'src/plugins/markdown.dart';
 export 'src/plugins/menus.dart';
 export 'src/plugins/pretty_urls.dart';

--- a/packages/static_shock/test/plugins/links_test.dart
+++ b/packages/static_shock/test/plugins/links_test.dart
@@ -1,0 +1,255 @@
+import 'dart:io';
+
+import 'package:static_shock/static_shock.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group("Links plugin >", () {
+    test("finds and reports bad external and internal URIs (no base URL set)", () async {
+      final errorLog = ErrorLog();
+      final context = _createFakeSite(Directory("test/fake/"), errorLog);
+
+      await BrokenLinkFinderFinisher().execute(context);
+
+      expect(errorLog.hasWarnings, isTrue);
+      expect(errorLog.warnings, [
+        StaticShockError.warning(
+          "Bad external URL found on page '/guides/getting-started': 'https://staticshock.io/does/not/exist'",
+        ),
+        StaticShockError.warning(
+          "Bad internal URL/path found on page '/guides/getting-started': '/root/relative/url/'",
+        ),
+        StaticShockError.warning(
+          "Bad internal URL/path found on page '/guides/getting-started': 'relative/url/index.html'",
+        ),
+      ]);
+    });
+
+    test("finds and reports bad external and internal URIs (with base URL set)", () async {
+      final errorLog = ErrorLog();
+      final context = _createFakeSite(Directory("test/fake/"), errorLog);
+      context.dataIndex.mergeAtPath(DirectoryRelativePath("/"), {
+        "baseUrl": "https://staticshock.io",
+      });
+
+      await BrokenLinkFinderFinisher().execute(context);
+
+      expect(errorLog.hasWarnings, isTrue);
+      expect(errorLog.warnings, [
+        StaticShockError.warning(
+          "Bad internal URL/path found on page '/guides/getting-started': 'https://staticshock.io/does/not/exist'",
+        ),
+        StaticShockError.warning(
+          "Bad internal URL/path found on page '/guides/getting-started': '/root/relative/url/'",
+        ),
+        StaticShockError.warning(
+          "Bad internal URL/path found on page '/guides/getting-started': 'relative/url/index.html'",
+        ),
+      ]);
+    });
+
+    // TODO: Add test for relative links
+
+    // TODO: Add test that shows drafting pages are ignored
+
+    group("HTML URL finder >", () {
+      test("finds URLs in HTML", () {
+        final linkFinder = HtmlLinkFinder();
+        final links = linkFinder.findAnchorLinks(_fakeHtml);
+
+        expect(
+          links,
+          [
+            Uri.parse("https://google.com"),
+            Uri.parse("https://www.flutter.dev"),
+            Uri.parse("/root/relative/url"),
+            Uri.parse("/root/relative/url/"),
+            Uri.parse("/root/relative/url/index.html"),
+            Uri.parse("relative/url"),
+            Uri.parse("relative/url/"),
+            Uri.parse("relative/url/index.html"),
+          ],
+        );
+      });
+
+      test("identifies bad URLs", () async {
+        final urlValidator = UrlValidator();
+        final badUrls = await urlValidator.findDeadUrls([
+          Uri.parse("https://google.com"),
+          Uri.parse("https://staticshock.io/does/not/exist/"),
+          Uri.parse("https://flutter.dev"),
+          Uri.parse("https://www.staticshock.io/nothing.html"),
+        ]);
+
+        expect(badUrls, [
+          Uri.parse("https://staticshock.io/does/not/exist/"),
+          Uri.parse("https://www.staticshock.io/nothing.html"),
+        ]);
+      });
+    });
+
+    group("URI selector >", () {
+      // Create one test for each of the possible ways that the base site might be
+      // encoded by the user, e.g., "https://staticshock.io" vs "www.staticshock.io"
+      // vs "staticshock.io".
+      for (final siteUrlPrefix in _SiteUrlPrefix.values) {
+        test("with base URL, finds external URLs, internal URLs, and internal paths (${siteUrlPrefix.name})", () async {
+          final baseUri = siteUrlPrefix.makeUrl("staticshock.io");
+
+          // A list of links that might exist in a real website.
+          final uris = [
+            Uri.parse("https://google.com"),
+            Uri.parse("http://google.com"),
+            Uri.parse("www.flutter.dev"),
+            Uri.parse("superdeclarative.com"),
+            Uri.parse("https://staticshock.io"),
+            Uri.parse("www.staticshock.io"),
+            Uri.parse("staticshock.io"),
+            Uri.parse("https://staticshock.io/welcome"),
+            Uri.parse("/guides/getting-started"),
+            Uri.parse("subpath/to/somewhere"),
+          ];
+
+          // Ensure that we can pick out the links that point to other websites.
+          expect(uris.whereRemote(baseUri).toList(), [
+            Uri.parse("https://google.com"),
+            Uri.parse("http://google.com"),
+            Uri.parse("www.flutter.dev"),
+            Uri.parse("superdeclarative.com"),
+          ]);
+
+          // Ensure that we can pick out the links that point to our website.
+          expect(uris.whereLocal(baseUri).toList(), [
+            Uri.parse("https://staticshock.io"),
+            Uri.parse("www.staticshock.io"),
+            Uri.parse("staticshock.io"),
+            Uri.parse("https://staticshock.io/welcome"),
+            Uri.parse("/guides/getting-started"),
+            Uri.parse("subpath/to/somewhere"),
+          ]);
+        });
+      }
+
+      test("with no URL, finds external URLs, internal URLs, and internal paths", () async {
+        final baseUri = null;
+
+        // A list of links that might exist in a real website.
+        final uris = [
+          Uri.parse("https://google.com"),
+          Uri.parse("http://google.com"),
+          Uri.parse("www.flutter.dev"),
+          Uri.parse("superdeclarative.com"),
+          Uri.parse("https://staticshock.io"),
+          Uri.parse("www.staticshock.io"),
+          Uri.parse("staticshock.io"),
+          Uri.parse("https://staticshock.io/welcome"),
+          Uri.parse("/guides/getting-started"),
+          Uri.parse("subpath/to/somewhere"),
+        ];
+
+        // Ensure that we can pick out the links that point to other websites.
+        expect(uris.whereRemote(baseUri).toList(), [
+          Uri.parse("https://google.com"),
+          Uri.parse("http://google.com"),
+          Uri.parse("www.flutter.dev"),
+          Uri.parse("superdeclarative.com"),
+          Uri.parse("https://staticshock.io"),
+          Uri.parse("www.staticshock.io"),
+          Uri.parse("staticshock.io"),
+          Uri.parse("https://staticshock.io/welcome"),
+        ]);
+
+        // Ensure that we can pick out paths from URLs.
+        expect(uris.whereLocal(baseUri).toList(), [
+          Uri.parse("/guides/getting-started"),
+          Uri.parse("subpath/to/somewhere"),
+        ]);
+      });
+    });
+  });
+}
+
+enum _SiteUrlPrefix {
+  fullyQualified,
+  justScheme,
+  justWWW,
+  none;
+
+  Uri makeUrl(String domain) {
+    switch (this) {
+      case _SiteUrlPrefix.fullyQualified:
+        return Uri.parse("https://www.$domain");
+      case _SiteUrlPrefix.justScheme:
+        return Uri.parse("https://$domain");
+      case _SiteUrlPrefix.justWWW:
+        return Uri.parse("www.$domain");
+      case _SiteUrlPrefix.none:
+        return Uri.parse(domain);
+    }
+  }
+
+  String get name {
+    switch (this) {
+      case _SiteUrlPrefix.fullyQualified:
+        return "fully-qualified";
+      case _SiteUrlPrefix.justScheme:
+        return "just scheme";
+      case _SiteUrlPrefix.justWWW:
+        return "just WWW";
+      case _SiteUrlPrefix.none:
+        return "no prefix";
+    }
+  }
+}
+
+StaticShockPipelineContext _createFakeSite(Directory sourceDirectory, [ErrorLog? errorLog]) {
+  final context = StaticShockPipelineContext(
+    sourceDirectory: sourceDirectory,
+    errorLog: errorLog ?? ErrorLog(),
+  );
+
+  context.pagesIndex.addPage(
+    Page(FileRelativePath("guides/getting-started.md", "fake", "md"), "") //
+      ..destinationContent = _gettingStartedHtml
+      ..pagePath = "/guides/getting-started",
+  );
+
+  return context;
+}
+
+const _fakeHtml = '''
+<!--suppress HtmlUnknownTarget, HtmlRequiredLangAttribute -->
+<html>
+<!--suppress HtmlRequiredTitleElement -->
+<head></head>
+<body>
+  <ul>
+    <li><a href="https://google.com">Google</a></li>
+    <li><a title="Flutter" href='https://www.flutter.dev'>Flutter</a></li>
+    <li><a class="link" href="/root/relative/url">Root relative directory no /</a></li>
+    <li><a href='/root/relative/url/' class="link">Root relative directory with /</a></li>
+    <li><a href='/root/relative/url/index.html'>Root relative HTML page</a></li>
+    <li><a href="relative/url">Relative directory no /</a></li>
+    <li><a href='relative/url/'>Relative directory with /</a></li>
+    <li><a href='relative/url/index.html'>Relative HTML page</a></li>
+    <li><a href='#some-section'>This shouldn't be picked up at all</a></li>
+  </ul>
+</body>
+</html>''';
+
+const _gettingStartedHtml = '''
+<!--suppress HtmlUnknownTarget, HtmlRequiredLangAttribute -->
+<html>
+<!--suppress HtmlRequiredTitleElement -->
+<head>
+  <title>Welcome</title>
+</head>
+<body>
+  <ul>
+    <li><a href='https://flutter.dev'>Flutter</a></li>
+    <li><a href='https://staticshock.io/does/not/exist'>Flutter</a></li>
+    <li><a href='/root/relative/url/' class="link">Root relative directory with /</a></li>
+    <li><a href='relative/url/index.html'>Relative HTML page</a></li>
+  </ul>
+</body>
+</html>''';

--- a/packages/static_shock/test/plugins/links_test.dart
+++ b/packages/static_shock/test/plugins/links_test.dart
@@ -14,13 +14,13 @@ void main() {
       expect(errorLog.hasWarnings, isTrue);
       expect(errorLog.warnings, [
         StaticShockError.warning(
-          "Bad external URL found on page '/guides/getting-started': 'https://staticshock.io/does/not/exist'",
+          "Bad external URL found on page '/guides/getting-started' (Getting Started): 'https://staticshock.io/does/not/exist'",
         ),
         StaticShockError.warning(
-          "Bad internal URL/path found on page '/guides/getting-started': '/root/relative/url/'",
+          "Bad internal URL/path found on page '/guides/getting-started' (Getting Started): '/root/relative/url/'",
         ),
         StaticShockError.warning(
-          "Bad internal URL/path found on page '/guides/getting-started': 'relative/url/index.html'",
+          "Bad internal URL/path found on page '/guides/getting-started' (Getting Started): '/guides/getting-started/relative/url/index.html'",
         ),
       ]);
     });
@@ -37,13 +37,13 @@ void main() {
       expect(errorLog.hasWarnings, isTrue);
       expect(errorLog.warnings, [
         StaticShockError.warning(
-          "Bad internal URL/path found on page '/guides/getting-started': 'https://staticshock.io/does/not/exist'",
+          "Bad internal URL/path found on page '/guides/getting-started' (Getting Started): 'https://staticshock.io/does/not/exist'",
         ),
         StaticShockError.warning(
-          "Bad internal URL/path found on page '/guides/getting-started': '/root/relative/url/'",
+          "Bad internal URL/path found on page '/guides/getting-started' (Getting Started): '/root/relative/url/'",
         ),
         StaticShockError.warning(
-          "Bad internal URL/path found on page '/guides/getting-started': 'relative/url/index.html'",
+          "Bad internal URL/path found on page '/guides/getting-started' (Getting Started): '/guides/getting-started/relative/url/index.html'",
         ),
       ]);
     });
@@ -208,8 +208,18 @@ StaticShockPipelineContext _createFakeSite(Directory sourceDirectory, [ErrorLog?
     errorLog: errorLog ?? ErrorLog(),
   );
 
+  context.dataIndex.mergeAtPath(DirectoryRelativePath("/"), {
+    "basePath": "/",
+  });
+
   context.pagesIndex.addPage(
-    Page(FileRelativePath("guides/getting-started.md", "fake", "md"), "") //
+    Page(
+      FileRelativePath("guides/getting-started.md", "fake", "md"),
+      "",
+      data: {
+        PageKeys.title: "Getting Started",
+      },
+    ) //
       ..destinationContent = _gettingStartedHtml
       ..pagePath = "/guides/getting-started",
   );

--- a/packages/static_shock/test/plugins/pretty_urls_test.dart
+++ b/packages/static_shock/test/plugins/pretty_urls_test.dart
@@ -6,7 +6,10 @@ import 'package:test/test.dart';
 void main() {
   group("Plugins > pretty URLs >", () {
     test("pretties URL for page with single source file", () async {
-      final context = StaticShockPipelineContext(Directory("/User/Fake/website"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("/User/Fake/website"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./posts/news", "fake", "md"), "");
       context.pagesIndex.addPage(page);
 
@@ -16,7 +19,10 @@ void main() {
     });
 
     test("pretties URL for page with explicit index file", () async {
-      final context = StaticShockPipelineContext(Directory("/User/Fake/website"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("/User/Fake/website"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./posts/news/fake", "index", "md"), "");
       context.pagesIndex.addPage(page);
 
@@ -26,7 +32,10 @@ void main() {
     });
 
     test("pretties URL for root-level page", () async {
-      final context = StaticShockPipelineContext(Directory("/User/Fake/website"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("/User/Fake/website"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./", "fake", "md"), "");
       context.pagesIndex.addPage(page);
 
@@ -36,7 +45,10 @@ void main() {
     });
 
     test("keeps root level index HTML file as-is", () async {
-      final context = StaticShockPipelineContext(Directory("/User/Fake/website"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("/User/Fake/website"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./", "index", "html"), "");
       context.pagesIndex.addPage(page);
 
@@ -46,7 +58,10 @@ void main() {
     });
 
     test("keeps root level index Markdown file as-is", () async {
-      final context = StaticShockPipelineContext(Directory("/User/Fake/website"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("/User/Fake/website"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./", "index", "md"), "");
       context.pagesIndex.addPage(page);
 

--- a/packages/static_shock/test/plugins/redirects_test.dart
+++ b/packages/static_shock/test/plugins/redirects_test.dart
@@ -10,7 +10,10 @@ void main() {
       // Sets up a `Page` that requests a redirect from `redirectFrom` to the given page,
       // and then verifies that a dedicated redirect page was created for the old URL.
       void redirectsFrom(String redirectFrom, String redirectTo) {
-        final context = StaticShockPipelineContext(Directory("test/fake/"));
+        final context = StaticShockPipelineContext(
+          sourceDirectory: Directory("test/fake/"),
+          errorLog: ErrorLog(),
+        );
         final page = Page(FileRelativePath("./fake_source", "fake", "md"), "") //
           ..destinationContent = _basicHtml
           ..pagePath = redirectTo
@@ -31,7 +34,10 @@ void main() {
     test("does not try to redirect when given an absolute path", () async {
       // Pages can't control the base path of a website, so absolute paths
       // make no sense as a redirect path.
-      final context = StaticShockPipelineContext(Directory("test/fake/"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("test/fake/"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./fake_source", "fake", "md"), "") //
         ..destinationContent = _basicHtml
         ..pagePath = "new/dir"
@@ -46,7 +52,10 @@ void main() {
 
     test("inserts redirect tag in variety of HTML with standard base path", () {
       void insertsRedirectTag(String html) {
-        final context = StaticShockPipelineContext(Directory("test/fake/"));
+        final context = StaticShockPipelineContext(
+          sourceDirectory: Directory("test/fake/"),
+          errorLog: ErrorLog(),
+        );
         final page = Page(FileRelativePath("./fake_source", "fake", "md"), "") //
           ..destinationContent = html
           ..pagePath = "new/dir"
@@ -79,7 +88,10 @@ void main() {
 
     test("inserts redirect tag in variety of HTML with custom base path", () {
       void insertsRedirectTag(String html) {
-        final context = StaticShockPipelineContext(Directory("test/fake/"));
+        final context = StaticShockPipelineContext(
+          sourceDirectory: Directory("test/fake/"),
+          errorLog: ErrorLog(),
+        );
         final page = Page(FileRelativePath("./fake_source", "fake", "md"), "") //
           ..destinationContent = html
           ..pagePath = "new/dir"
@@ -111,7 +123,10 @@ void main() {
     });
 
     test("does not redirect when missing HEAD tag", () {
-      final context = StaticShockPipelineContext(Directory("test/fake/"));
+      final context = StaticShockPipelineContext(
+        sourceDirectory: Directory("test/fake/"),
+        errorLog: ErrorLog(),
+      );
       final page = Page(FileRelativePath("./fake_source", "fake", "md"), "") //
         ..destinationContent = _missingHeadHtml
         ..pagePath = "new/dir"

--- a/packages/static_shock_cli/lib/src/commands/serve_command.dart
+++ b/packages/static_shock_cli/lib/src/commands/serve_command.dart
@@ -30,6 +30,11 @@ class ServeCommand extends Command with PubVersionCheck {
         "base-path",
         defaultsTo: null,
         help: "Base path that's expected to begin every URL path.",
+      )
+      ..addOption(
+        "build-mode",
+        defaultsTo: "dev",
+        help: "The build mode to use for the website build, e.g., 'production', 'dev'.",
       );
   }
 
@@ -49,6 +54,8 @@ class ServeCommand extends Command with PubVersionCheck {
   Future<void> run() async {
     await super.run();
 
+    final buildMode = argResults!.option("build-mode") ?? "production";
+
     // Run a website build just in case the user has never built, or hasn't built recently.
     log.info("Building website.");
     try {
@@ -57,7 +64,12 @@ class ServeCommand extends Command with PubVersionCheck {
       }
 
       final result = await buildWebsite(
-        appArguments: argResults?.rest ?? [],
+        appArguments: [
+          if (argResults != null) ...[
+            ...argResults!.rest,
+            "--build-mode", buildMode, //
+          ],
+        ],
       );
       if (result == null) {
         log.err("Failed to build website, therefore not starting the dev server.");
@@ -86,6 +98,7 @@ class ServeCommand extends Command with PubVersionCheck {
       port: port,
       findAnOpenPort: isPortSearchingAllowed,
       basePath: basePath,
+      buildMode: buildMode,
     );
   }
 }

--- a/packages/static_shock_cli/lib/src/dev_server.dart
+++ b/packages/static_shock_cli/lib/src/dev_server.dart
@@ -56,6 +56,7 @@ class StaticShockDevServer {
     required int port,
     bool findAnOpenPort = false,
     String? basePath,
+    String? buildMode,
   }) async {
     if (_isServing) {
       _log.err("Tried to start a dev server, but it's already running!");

--- a/packages/static_shock_docs/bin/static_shock_docs.dart
+++ b/packages/static_shock_docs/bin/static_shock_docs.dart
@@ -9,6 +9,7 @@ Future<void> main(List<String> arguments) async {
       rootUrl: 'https://staticshock.io',
       basePath: '/',
     ),
+    cliArguments: arguments,
   )
     ..pick(DirectoryPicker.parse("images"))
     ..plugin(const MarkdownPlugin())
@@ -19,10 +20,9 @@ Future<void> main(List<String> arguments) async {
     ))
     ..plugin(const PrettyUrlsPlugin())
     ..plugin(const RedirectsPlugin())
+    ..plugin(const LinksPlugin())
     ..plugin(const SassPlugin())
-    ..plugin(DraftingPlugin(
-      showDrafts: arguments.contains("preview"),
-    ))
+    ..plugin(const DraftingPlugin())
     ..plugin(const PubPackagePlugin())
     ..plugin(WebsiteScreenshotsPlugin(
       selector: (context) {

--- a/packages/static_shock_docs/source/concepts/_data.yaml
+++ b/packages/static_shock_docs/source/concepts/_data.yaml
@@ -1,6 +1,6 @@
 layout: layouts/guides.jinja
 docs_menu:
-  base_path: concepts
+  base_path: /concepts
   items:
     - title: How it Works
       id: how-it-works

--- a/packages/static_shock_docs/source/concepts/directory.jinja
+++ b/packages/static_shock_docs/source/concepts/directory.jinja
@@ -1,0 +1,60 @@
+<!--
+title: Concepts
+layout: ""
+-->
+<!doctype html>
+
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }} | Static Shock</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {{ components.headerResources() }}
+
+    <link rel="stylesheet" href="/styles/theme.css">
+    <link rel="stylesheet" href="/styles/base_layout.css">
+    <link rel="stylesheet" href="/styles/inner_page.css">
+    <link rel="stylesheet" href="/styles/guides.css">
+    <link rel="stylesheet" href="/styles/directory.css">
+  </head>
+
+  <body class="inner-page">
+    <main>
+      {{ components.githubCornerLink() }}
+
+      {{ components.navbar({"title": title}) }}
+
+      <!-- Primary page content -->
+      <div id="content" class="container">
+        <h1>Concepts</h1>
+
+        <nav id="menu">
+          {% for menuItem in docs_menu.items %}
+
+            {% if menuItem.items %}
+              {# Show a menu sub-group with a header and child items #}
+              <p class="title">{{ menuItem.title }}</p>
+
+              {% set menuItemSubpath = docs_menu.base_path + "/" + menuItem.subPath if menuItem.subPath else docs_menu.base_path + "/" %}
+              {% for item in menuItem.items|itemsForExistingPages([menuItemSubpath]) %}
+                {% set menuItemUrlPath = menuItemSubpath + item.id %}
+                <a class="btn btn-primary btn-sm {{ 'active' if isCurrentPage(menuItemUrlPath) else '' }}" href="{{ menuItemUrlPath }}" role="button">{{ item.title }}</a>
+              {% endfor %}
+            {% else %}
+              {% set menuItemUrlPath = docs_menu.base_path + "/" + menuItem.id %}
+              <a class="btn btn-primary btn-sm {{ 'active' if isCurrentPage(menuItemUrlPath) else '' }}" href="{{ menuItemUrlPath }}" role="button">{{ menuItem.title }}</a>
+            {% endif %}
+
+          {% endfor %}
+        </nav>
+      </div>
+    </main>
+
+    <footer>
+      {{ components.footer() }}
+    </footer>
+
+    {{ components.endBodyScripts() }}
+  </body>
+</html>

--- a/packages/static_shock_docs/source/concepts/how-it-works/assets.md
+++ b/packages/static_shock_docs/source/concepts/how-it-works/assets.md
@@ -2,7 +2,7 @@
 title: Assets
 ---
 Assets are data structures that essentially represent any output file that isn't
-a [page](contributing/how-it-works/pages/). An asset might be a CSS file, JavaScript
+a [page](/concepts/how-it-works/pages/). An asset might be a CSS file, JavaScript
 file, image, video, etc.
 
 An `Asset` data structure only has two pieces of information: a source, and a destination.

--- a/packages/static_shock_docs/source/concepts/how-it-works/plugins.md
+++ b/packages/static_shock_docs/source/concepts/how-it-works/plugins.md
@@ -149,5 +149,5 @@ to CSS.
 ```
 
 The objects that plugins register with Static Shock are the various hooks
-supported by the `StaticShockPipeline`. See [the pipeline](concepts/how-it-works/the-pipeline)
+supported by the `StaticShockPipeline`. See [the pipeline](/concepts/how-it-works/the-pipeline)
 documentation to learn more about pipeline steps and hooks.

--- a/packages/static_shock_docs/source/contributing/_data.yaml
+++ b/packages/static_shock_docs/source/contributing/_data.yaml
@@ -1,6 +1,6 @@
 layout: layouts/guides.jinja
 docs_menu:
-  base_path: contributing
+  base_path: /contributing
   items:
     - title: Welcome
       id: welcome

--- a/packages/static_shock_docs/source/contributing/directory.jinja
+++ b/packages/static_shock_docs/source/contributing/directory.jinja
@@ -1,0 +1,60 @@
+<!--
+title: Contributing
+layout: ""
+-->
+<!doctype html>
+
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }} | Static Shock</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {{ components.headerResources() }}
+
+    <link rel="stylesheet" href="/styles/theme.css">
+    <link rel="stylesheet" href="/styles/base_layout.css">
+    <link rel="stylesheet" href="/styles/inner_page.css">
+    <link rel="stylesheet" href="/styles/guides.css">
+    <link rel="stylesheet" href="/styles/directory.css">
+  </head>
+
+  <body class="inner-page">
+    <main>
+      {{ components.githubCornerLink() }}
+
+      {{ components.navbar({"title": title}) }}
+
+      <!-- Primary page content -->
+      <div id="content" class="container">
+        <h1>Contributing</h1>
+
+        <nav id="menu">
+          {% for menuItem in docs_menu.items %}
+
+            {% if menuItem.items %}
+              {# Show a menu sub-group with a header and child items #}
+              <p class="title">{{ menuItem.title }}</p>
+
+              {% set menuItemSubpath = docs_menu.base_path + "/" + menuItem.subPath if menuItem.subPath else docs_menu.base_path + "/" %}
+              {% for item in menuItem.items|itemsForExistingPages([menuItemSubpath]) %}
+                {% set menuItemUrlPath = menuItemSubpath + item.id %}
+                <a class="btn btn-primary btn-sm {{ 'active' if isCurrentPage(menuItemUrlPath) else '' }}" href="{{ menuItemUrlPath }}" role="button">{{ item.title }}</a>
+              {% endfor %}
+            {% else %}
+              {% set menuItemUrlPath = docs_menu.base_path + "/" + menuItem.id %}
+              <a class="btn btn-primary btn-sm {{ 'active' if isCurrentPage(menuItemUrlPath) else '' }}" href="{{ menuItemUrlPath }}" role="button">{{ menuItem.title }}</a>
+            {% endif %}
+
+          {% endfor %}
+        </nav>
+      </div>
+    </main>
+
+    <footer>
+      {{ components.footer() }}
+    </footer>
+
+    {{ components.endBodyScripts() }}
+  </body>
+</html>

--- a/packages/static_shock_docs/source/contributing/getting-started/work-on-an-issue.md
+++ b/packages/static_shock_docs/source/contributing/getting-started/work-on-an-issue.md
@@ -24,7 +24,7 @@ easy to change a behavior in place only to have it break a behavior somewhere el
 
 You should expect to write tests for every bug fix and every feature.
 
-To help you, we've published an entire section on [testing](contributing/testing/overview/).
+To help you, we've published an entire section on [testing](/contributing/testing/overview/).
 
 ## Documentation
 What you're reading right now is documentation. The only reason these words exist is

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -1,6 +1,6 @@
 layout: layouts/guides.jinja
 docs_menu:
-  base_path: guides
+  base_path: /guides
   items:
     - title: Quickstart
       id: quickstart
@@ -20,6 +20,8 @@ docs_menu:
       items:
         - title: Deploy to GitHub Pages
           id: deploy-to-github-pages
+        - title: Validate Links
+          id: validate-links
     - title: Website
       id: website
       items:
@@ -37,10 +39,10 @@ docs_menu:
       items:
         - title: Links
           id: page-links
-        - title: Create a Page Layout
-          id: create-a-page-layout
-        - title: Create a Component
-          id: create-a-component
+#        - title: Create a Page Layout
+#          id: create-a-page-layout
+#        - title: Create a Component
+#          id: create-a-component
     - title: Drafting
       id: drafting
       items:
@@ -51,8 +53,8 @@ docs_menu:
       items:
         - title: Include Remote Files
           id: remote-files
-        - title: Use Remote CSS and JS
-          id: use-remote-css-and-js
+#        - title: Use Remote CSS and JS
+#          id: use-remote-css-and-js
     - title: Blogs
       id: blogs
       items:

--- a/packages/static_shock_docs/source/guides/validate-links.md
+++ b/packages/static_shock_docs/source/guides/validate-links.md
@@ -1,0 +1,27 @@
+---
+title: Validate Links
+---
+When it's time to deploy your website, it's important to know that all
+of your links work. It's easy to write links that you forget to update.
+Use the `LinksPlugin` to validate every internal and external anchor
+tag in your website.
+
+```dart
+final site = StaticShock(...)
+  ..plugin(const LinksPlugin());
+```
+
+By default, the `LinksPlugin` will fail the build for any broken links
+when building for production, but will only log warnings for broken links
+when building for development. The build mode is controlled by the
+`buildMode` property in `StaticShock`.
+
+You can directly control the error/warning mode by configuring the `LinksPlugin`.
+
+```dart
+final site = StaticShock(...)
+  ..plugin(const LinksPlugin(
+    shouldRunLinkVerification: true,
+    failBuildOnBrokenLinks: true,
+  ));
+```

--- a/packages/static_shock_docs/source/index.jinja
+++ b/packages/static_shock_docs/source/index.jinja
@@ -50,7 +50,7 @@ rss: false
                       <i class="fa fa-clone" style="color: black; font-size: 24px; font-weight: bold;"></i>
                     </button>
                   </div>
-                  <span class="call-to-action supplemental-text"><a href="/quickstart">Get started with our Quickstart guide</a></span>
+                  <span class="call-to-action supplemental-text"><a href="/guides/quickstart">Get started with our Quickstart guide</a></span>
                 </div>
                 <div class="col col-auto logo">
                   <img src="images/logo_big.png" width="225">


### PR DESCRIPTION
Add `LinksPlugin` to validate all anchor tag links in website (Resolves #183)

Added `basePath` property to the `StaticShockPipelineContext`.

Added `buildMode` to `StaticShock` and to `StaticShockPipelineContext` so that Static Shock and plugins can make decisions based on building for production vs development.

Added a `cliArguments` property to the `StaticShock` object, which is used to parse standard Static Shock arguments. The CLI arguments are also forwarded to the `StaticShockPipelineContext` so that they're available to plugins, allowing plugins to also utilize CLI arguments for configuration. `StaticShock` parses the build mode from the CLI args, defaulting to `production`.

Added an `ErrorLog` to `StaticShockPipelineContext` so that plugins can report warnings, which are reported to the terminal but don't fail the build, errors which are reported to the terminal and fail the build but allow execution to continue, and crashes, which throw an `Exception` immediately.

Changed `DraftingPlugin` so that the `showDrafts` is optional, and if it's `null`, the plugin attempts to pull a `--preview` flag from the `cliArguments`.