### PR TITLE
Expand LinksPlugin to find missing pages since last build (Resolves #184)

### DIFF
--- a/packages/static_shock/lib/src/static_shock.dart
+++ b/packages/static_shock/lib/src/static_shock.dart
@@ -90,6 +90,16 @@ class StaticShock implements StaticShockPipeline {
       return;
     }
 
+    if (arguments.contains("--production")) {
+      _buildMode = StaticShockBuildMode.production;
+      return;
+    }
+
+    if (arguments.contains("--dev")) {
+      _buildMode = StaticShockBuildMode.dev;
+      return;
+    }
+
     final buildModeArgs = arguments.where((arg) => arg.startsWith("--build-mode"));
     if (buildModeArgs.isEmpty) {
       // No explicit build mode.

--- a/packages/static_shock/test/plugins/links_test.dart
+++ b/packages/static_shock/test/plugins/links_test.dart
@@ -9,7 +9,7 @@ void main() {
       final errorLog = ErrorLog();
       final context = _createFakeSite(Directory("test/fake/"), errorLog);
 
-      await BrokenLinkFinderFinisher().execute(context);
+      await BrokenLinkFinderFinisher(shouldRunLinkVerification: true).execute(context);
 
       expect(errorLog.hasWarnings, isTrue);
       expect(errorLog.warnings, [
@@ -32,7 +32,7 @@ void main() {
         "baseUrl": "https://staticshock.io",
       });
 
-      await BrokenLinkFinderFinisher().execute(context);
+      await BrokenLinkFinderFinisher(shouldRunLinkVerification: true).execute(context);
 
       expect(errorLog.hasWarnings, isTrue);
       expect(errorLog.warnings, [

--- a/packages/static_shock_cli/lib/src/commands/build_command.dart
+++ b/packages/static_shock_cli/lib/src/commands/build_command.dart
@@ -4,7 +4,11 @@ import 'package:static_shock_cli/src/website_builder.dart';
 
 /// CLI [Command] that builds a Static Shock website from source files.
 class BuildCommand extends Command {
-  BuildCommand(this.log);
+  BuildCommand(this.log) {
+    argParser //
+      ..addFlag("production", help: "Build in production mode.")
+      ..addFlag("dev", help: "Build in dev mode");
+  }
 
   final Logger log;
 
@@ -24,8 +28,17 @@ class BuildCommand extends Command {
       log.detail("Passing extra arguments to the website builder: ${argResults!.rest.join(", ")}");
     }
 
+    log.detail("Production flag: ${argResults!.flag("production")}");
+    log.detail("Dev flag: ${argResults!.flag("dev")}");
+
     await buildWebsite(
-      appArguments: argResults?.rest ?? [],
+      appArguments: [
+        if (argResults!.flag("production")) //
+          "--production",
+        if (argResults!.flag("dev")) //
+          "--dev",
+        ...argResults!.rest,
+      ],
       log: log,
     );
   }

--- a/packages/static_shock_cli/lib/src/commands/build_command.dart
+++ b/packages/static_shock_cli/lib/src/commands/build_command.dart
@@ -28,9 +28,6 @@ class BuildCommand extends Command {
       log.detail("Passing extra arguments to the website builder: ${argResults!.rest.join(", ")}");
     }
 
-    log.detail("Production flag: ${argResults!.flag("production")}");
-    log.detail("Dev flag: ${argResults!.flag("dev")}");
-
     await buildWebsite(
       appArguments: [
         if (argResults!.flag("production")) //

--- a/packages/static_shock_docs/source/guides/_data.yaml
+++ b/packages/static_shock_docs/source/guides/_data.yaml
@@ -22,6 +22,8 @@ docs_menu:
           id: deploy-to-github-pages
         - title: Validate Links
           id: validate-links
+        - title: Find Missing Pages
+          id: find-missing-pages
     - title: Website
       id: website
       items:

--- a/packages/static_shock_docs/source/guides/find-missing-pages.md
+++ b/packages/static_shock_docs/source/guides/find-missing-pages.md
@@ -1,0 +1,45 @@
+---
+title: Find Missing Pages
+---
+When editing a static site, it's easy to forget that every page that you've deployed
+now has a public URL that others might depend upon. Users might add a URL to their
+bookmarks, or they might share the URL on social media. Therefore, it's typically
+recommended that you never remove an existing URL - you should only redirect it.
+
+The first step in making sure you don't break a public URL is to make sure that
+URL doesn't disappear from your website build. Another way to say the same thing
+is that you need to make sure pages don't disappear from one deployment to another.
+
+The `LinksPlugin` includes support for watching your pages from one deployment to
+the next, and it can alert you when pages disappear.
+
+```dart
+final site = StaticShock(...)
+  ..plugin(const LinksPlugin());
+```
+
+By default, the `LinksPlugin` updates its list of pages when you run a production build,
+but not when you run a development build. This is because what you're guarding against
+is the loss of published pages. Similarly, by default, the plugin ignores all pages in
+draft mode. 
+
+You can override these defaults.
+
+```dart
+final site = StaticShock(...)
+  ..plugin(const LinksPlugin(
+    pageManifestUpdatePolicy: PageManifestUpdatePolicy.forceUpdate,
+    includeDraftPagesInPageManifest: true,
+  ));
+```
+
+By default, the `LinksPlugin` reports missing pages as warnings in dev mode, and as errors
+in production mode. However, you can override the default behavior to report them however
+you'd like.
+
+```dart
+final site = StaticShock(...)
+  ..plugin(const LinksPlugin(
+    reportMissingPagesAtErrorLevel: StaticShockErrorLevel.warning,
+  ));
+```


### PR DESCRIPTION
Expand LinksPlugin to find missing pages since last build (Resolves #184)

CLI: Adds parsing of "--dev" and "--production" to set build mode, which is easier to type than "--build-mode production".