### PR TITLE
[Shock][CLI][Docs] - Load themes from git repositories (Resolves #213)

### DIFF
--- a/packages/static_shock/lib/src/pipeline.dart
+++ b/packages/static_shock/lib/src/pipeline.dart
@@ -5,14 +5,23 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:static_shock/src/data.dart';
 import 'package:static_shock/src/files.dart';
 import 'package:static_shock/src/finishers.dart';
+import 'package:static_shock/src/source_files.dart';
 import 'package:static_shock/src/templates/components.dart';
 import 'package:static_shock/src/templates/layouts.dart';
 
 import 'package:static_shock/src/assets.dart';
 import 'package:static_shock/src/pages.dart';
+import 'package:static_shock/src/themes.dart';
 
 /// A pipeline that runs a series of steps to generate a static website.
 abstract class StaticShockPipeline {
+  /// Adds the given [SourceFiles] to the collection of source files that are
+  /// pushed through the pipeline.
+  ///
+  /// There's only one true source directory, within the project, but users
+  /// can supplement the collection of source files with extensions.
+  void addSourceExtension(SourceFiles extensionFiles);
+
   /// Adds the given [picker] to the pipeline, which selects files that will
   /// be pushed through the pipeline.
   void pick(Picker picker);
@@ -37,6 +46,10 @@ abstract class StaticShockPipeline {
     Set<RemoteFileSource>? assets,
     Set<RemoteFileSource>? pages,
   });
+
+  /// Loads the given [theme], which is a collection of pages, assets, layouts,
+  /// and components.
+  void loadTheme(Theme theme);
 
   /// Adds the given [DataLoader] to the pipeline, which loads external data before
   /// any assets or pages are loaded.
@@ -112,6 +125,7 @@ class StaticShockPipelineContext {
     required Directory sourceDirectory,
     this.buildMode = StaticShockBuildMode.production,
     this.cliArguments = const [],
+    required this.buildCacheDirectory,
     required this.errorLog,
     Logger? log,
   })  : _sourceDirectory = sourceDirectory,
@@ -122,6 +136,8 @@ class StaticShockPipelineContext {
 
   /// {@macro cli_arguments}
   final List<String> cliArguments;
+
+  final Directory buildCacheDirectory;
 
   /// The shared [Logger] for all CLI output.
   ///
@@ -191,6 +207,7 @@ class StaticShockPipelineContext {
 
   /// Returns the [Layout] template from the given file [path].
   Layout? getLayout(FileRelativePath path) => _layouts[path];
+
   final _layouts = <FileRelativePath, Layout>{};
 
   /// Adds the given [layout] to the pipeline.

--- a/packages/static_shock/lib/src/plugins/sass.dart
+++ b/packages/static_shock/lib/src/plugins/sass.dart
@@ -74,6 +74,7 @@ class SassIndexTransformer implements AssetTransformer {
     }
 
     _log.detail("Adding Sass content to cache: ${asset.sourcePath}");
+    _log.detail("Content:\n${asset.sourceContent!.text}");
     _environment.cache["${asset.destinationPath!.filename}.${asset.destinationPath!.extension}"] =
         asset.sourceContent!.text!;
   }

--- a/packages/static_shock/lib/src/source_files.dart
+++ b/packages/static_shock/lib/src/source_files.dart
@@ -57,6 +57,11 @@ class SourceFiles {
               file,
               file.path.substring(directory.path.length),
             )) //
+        .where(
+          (file) =>
+              !file.subPath.startsWith("_includes") && //
+              !file.subPath.startsWith("/_includes"),
+        )
         .where((file) => !_isExcluded(file.subPath))
         .where((file) => filter?.passesFilter(file) ?? true);
   }

--- a/packages/static_shock/lib/src/themes.dart
+++ b/packages/static_shock/lib/src/themes.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:path/path.dart';
+import 'package:static_shock/src/files.dart';
+import 'package:static_shock/src/pipeline.dart';
+import 'package:static_shock/src/source_files.dart';
+
+abstract class Theme {
+  static Theme fromGit({
+    required String url,
+    String? path,
+    String? ref,
+  }) =>
+      GitTheme(url: url, path: path, ref: ref);
+
+  Future<void> load(StaticShockPipeline pipeline, StaticShockPipelineContext context);
+
+  String get describe;
+}
+
+class GitTheme implements Theme {
+  const GitTheme({
+    required this.url,
+    this.path,
+    this.ref,
+  });
+
+  final String url;
+  final String? path;
+  final String? ref;
+
+  @override
+  Future<void> load(StaticShockPipeline pipeline, StaticShockPipelineContext context) async {
+    final normalizedUrl = Uri.parse(url).normalizePath();
+    final directoryName = "${normalizedUrl.host}/${normalizedUrl.path}".replaceAll("/", "_");
+
+    final cloneDirectory = context.buildCacheDirectory.subDir(["themes", "git", directoryName]).absolute;
+    cloneDirectory.createSync(recursive: true);
+
+    // Clone the theme repo into the build cache. This repo might already exist
+    // here in the cache, but trying to clone again shouldn't cause any issues.
+    await Process.run("git", ["clone", url, cloneDirectory.path]);
+
+    // Checkout the desired ref.
+    await Process.run("git", ["fetch", "origin"], workingDirectory: cloneDirectory.path);
+    if (ref != null) {
+      final result = await Process.run("git", ["checkout", ref!], workingDirectory: cloneDirectory.path);
+      if (result.exitCode != 0) {
+        context.errorLog.crash("Failed to checkout Git theme ref ($ref): ${result.stderr}");
+      }
+    } else {
+      final result = await Process.run("git", ["checkout", "HEAD"], workingDirectory: cloneDirectory.path);
+      if (result.exitCode != 0) {
+        context.errorLog.crash("Failed to checkout Git theme ref (HEAD): ${result.stderr}");
+      }
+    }
+
+    // Pull the latest for the branch.
+    await Process.run("git", ["pull"], workingDirectory: cloneDirectory.path);
+
+    // Walk all files within the desired path and add them to the pipeline.
+    final themeDirectory = path != null ? cloneDirectory.subDir(path!.split(separator)) : cloneDirectory;
+
+    final sourceFiles = SourceFiles(
+      directory: themeDirectory,
+      excludedPaths: {},
+    );
+
+    pipeline.addSourceExtension(sourceFiles);
+  }
+
+  @override
+  String get describe => "Theme (from git) - url: $url, path: ${path ?? "none"}, ref: ${ref ?? "none"}";
+}

--- a/packages/static_shock/lib/static_shock.dart
+++ b/packages/static_shock/lib/static_shock.dart
@@ -8,6 +8,7 @@ export 'src/pages.dart';
 export 'src/pipeline.dart';
 export 'src/source_files.dart';
 export 'src/static_shock.dart';
+export 'src/themes.dart';
 export 'src/templates/components.dart';
 export 'src/templates/layouts.dart';
 

--- a/packages/static_shock_docs/.gitignore
+++ b/packages/static_shock_docs/.gitignore
@@ -1,10 +1,8 @@
 # Build output
 /build
 
-# Shock cache and temp files
-# (Jan 12, 2024) - I started committing the cache because we're able to generate screenshots
-#                  locally, but puppeteer is broken on CI.
-#/source/.shock/
+# Build cache
+.shock
 
 # Puppeteer cached output
 .local-chrome

--- a/packages/static_shock_docs/bin/static_shock_docs.dart
+++ b/packages/static_shock_docs/bin/static_shock_docs.dart
@@ -11,6 +11,12 @@ Future<void> main(List<String> arguments) async {
     ),
     cliArguments: arguments,
   )
+    ..loadTheme(
+      Theme.fromGit(
+        url: "https://github.com/flutter-bounty-hunters/fbh_docs_theme",
+        path: "theme",
+      ),
+    )
     ..pick(DirectoryPicker.parse("images"))
     ..plugin(const MarkdownPlugin())
     ..plugin(JinjaPlugin(

--- a/packages/static_shock_docs/source/test-layout.md
+++ b/packages/static_shock_docs/source/test-layout.md
@@ -1,0 +1,25 @@
+---
+title: Test Docs Layout
+layout: layouts/docs_page.jinja
+
+# Configuration for the package that this website documents.
+package:
+  name: super_editor
+  title: Super Editor
+  description: Tools for easily simulating user behavior in widget tests
+  is_on_pub: true
+  github:
+    url: https://github.com/superlistapp/super_editor
+    organization: superlistapp
+    name: super_editor
+  discord: https://discord.gg/8hna2VD32s
+  sponsorship: https://flutterbountyhunters.com
+
+# Configuration of the GitHub plugin for loading info about GitHub repositories.
+github:
+  contributors:
+    repositories:
+      - { organization: superlistapp, name: super_editor }
+---
+# Docs Page Layout Test
+This is a test of the remote layout from GitHub.

--- a/template_sources/template_blog/.gitignore
+++ b/template_sources/template_blog/.gitignore
@@ -1,8 +1,8 @@
 # Build output
 /build
 
-# Shock cache and temp files
-/source/.shock/
+# Build cache
+.shock
 
 # Puppeteer cached output
 .local-chrome

--- a/template_sources/template_docs_multi_page/.gitignore
+++ b/template_sources/template_docs_multi_page/.gitignore
@@ -1,8 +1,8 @@
 # Build output
 /build
 
-# Shock cache and temp files
-/source/.shock/
+# Build cache
+.shock
 
 # Puppeteer cached output
 .local-chrome

--- a/template_sources/template_empty/.gitignore
+++ b/template_sources/template_empty/.gitignore
@@ -1,8 +1,8 @@
 # Build output
 /build
 
-# Shock cache and temp files
-/source/.shock/
+# Build cache
+.shock
 
 # Puppeteer cached output
 .local-chrome


### PR DESCRIPTION
[Shock][CLI][Docs] - Load themes from git repositories (Resolves #213)

**Git theme specification**
A git theme is specified by a URL, and an optional path within the repository.

The path is important because it's very likely that a theme will be stored in a subdirectory so that it doesn't include things like the `.gitignore` file at the root. That said, a website could always use an `Excluder` to keep files like `.gitignore` out of the pipeline.

**Git theme implementation**
Based on initial research, it looks like Git doesn't support any standard repository directory traversal. My hope was that we could navigate the repo over HTTP and only pull down what's picked, but Git doesn't support that.

Instead, we clone the entire theme repository, but we tell git to only bring down the content at the given `path`. This should avoid excessive clone size for things like mono-repos.

The theme repo is cloned to the a new root level `.shock/build/` build cache directory. It's contents are added as a source set so that its files can be picked, like the regular source set.

**Infrastructure changes**
 * Can add file sources that supplement the primary source directory.
 * Added a build cache that's placed in a `.shock` directory at the root of the project structure. I couldn't place it in `/build` because that directory is cleared on every build, and also it's meant to be directly deployable. I also didn't want to place it in `/source` because it isn't actually source.
   * Note: Based on previous work, specifically screenshots, the cache under `/source/.shock/` is no longer git ignored. We commit it so that things like screenshots don't need to be regenerated in CI, or over time, if not desired.
 * Had to change uses of `FileRelativePath`s to `SourceFile`s because we no longer know that every file exists relative to the primary source directory.